### PR TITLE
feat: add updateRequestId and authExpiryTime to AlipayPayResultNotify

### DIFF
--- a/com/alipay/ams/api/model/payment_result_info.py
+++ b/com/alipay/ams/api/model/payment_result_info.py
@@ -37,6 +37,9 @@ class PaymentResultInfo:
         self.__rrn = None  # type: str
         self.__user_authorization_status = None  # type: str
         self.__authorization_code = None  # type: str
+        self.__incremental_authorization_available = None  # type: bool
+        self.__extended_authorization_available = None  # type: bool
+        self.__refund_on_authorization_available = None  # type: bool
         
 
     @property
@@ -319,6 +322,36 @@ class PaymentResultInfo:
     @authorization_code.setter
     def authorization_code(self, value):
         self.__authorization_code = value
+    @property
+    def incremental_authorization_available(self):
+        """
+        Whether this pre-auth supports incremental auth. Returned when auth is successful.
+        """
+        return self.__incremental_authorization_available
+
+    @incremental_authorization_available.setter
+    def incremental_authorization_available(self, value):
+        self.__incremental_authorization_available = value
+    @property
+    def extended_authorization_available(self):
+        """
+        Whether this pre-auth supports extended auth. Returned when auth is successful.
+        """
+        return self.__extended_authorization_available
+
+    @extended_authorization_available.setter
+    def extended_authorization_available(self, value):
+        self.__extended_authorization_available = value
+    @property
+    def refund_on_authorization_available(self):
+        """
+        Whether subsequent refunds can be made via paymentId. Returned when auth is successful.
+        """
+        return self.__refund_on_authorization_available
+
+    @refund_on_authorization_available.setter
+    def refund_on_authorization_available(self, value):
+        self.__refund_on_authorization_available = value
 
 
     
@@ -381,6 +414,12 @@ class PaymentResultInfo:
             params['userAuthorizationStatus'] = self.user_authorization_status
         if hasattr(self, "authorization_code") and self.authorization_code is not None:
             params['authorizationCode'] = self.authorization_code
+        if hasattr(self, "incremental_authorization_available") and self.incremental_authorization_available is not None:
+            params['incrementalAuthorizationAvailable'] = self.incremental_authorization_available
+        if hasattr(self, "extended_authorization_available") and self.extended_authorization_available is not None:
+            params['extendedAuthorizationAvailable'] = self.extended_authorization_available
+        if hasattr(self, "refund_on_authorization_available") and self.refund_on_authorization_available is not None:
+            params['refundOnAuthorizationAvailable'] = self.refund_on_authorization_available
         return params
 
 
@@ -446,3 +485,9 @@ class PaymentResultInfo:
             self.__user_authorization_status = response_body['userAuthorizationStatus']
         if 'authorizationCode' in response_body:
             self.__authorization_code = response_body['authorizationCode']
+        if 'incrementalAuthorizationAvailable' in response_body:
+            self.__incremental_authorization_available = response_body['incrementalAuthorizationAvailable']
+        if 'extendedAuthorizationAvailable' in response_body:
+            self.__extended_authorization_available = response_body['extendedAuthorizationAvailable']
+        if 'refundOnAuthorizationAvailable' in response_body:
+            self.__refund_on_authorization_available = response_body['refundOnAuthorizationAvailable']

--- a/com/alipay/ams/api/model/plan.py
+++ b/com/alipay/ams/api/model/plan.py
@@ -14,6 +14,7 @@ class Plan:
         self.__installment_num = None  # type: str
         self.__interval = None  # type: str
         self.__enabled = None  # type: bool
+        self.__extend_info = None  # type: str
         
 
     @property
@@ -76,6 +77,16 @@ class Plan:
     @enabled.setter
     def enabled(self, value):
         self.__enabled = value
+    @property
+    def extend_info(self):
+        """
+        Extended information field, used to return extended information of the payment installment plan in the payment consultation interface. The extended fields in the installment plan include interest rates and various amount details to meet the merchant&#39;s amount display requirements.  More information:  Maximum length: 4096 characters
+        """
+        return self.__extend_info
+
+    @extend_info.setter
+    def extend_info(self, value):
+        self.__extend_info = value
 
 
     
@@ -94,6 +105,8 @@ class Plan:
             params['interval'] = self.interval
         if hasattr(self, "enabled") and self.enabled is not None:
             params['enabled'] = self.enabled
+        if hasattr(self, "extend_info") and self.extend_info is not None:
+            params['extendInfo'] = self.extend_info
         return params
 
 
@@ -114,3 +127,5 @@ class Plan:
             self.__interval = response_body['interval']
         if 'enabled' in response_body:
             self.__enabled = response_body['enabled']
+        if 'extendInfo' in response_body:
+            self.__extend_info = response_body['extendInfo']

--- a/com/alipay/ams/api/model/transaction.py
+++ b/com/alipay/ams/api/model/transaction.py
@@ -4,6 +4,8 @@ from com.alipay.ams.api.model.transaction_type import TransactionType
 from com.alipay.ams.api.model.transaction_status_type import TransactionStatusType
 from com.alipay.ams.api.model.amount import Amount
 from com.alipay.ams.api.model.acquirer_info import AcquirerInfo
+from com.alipay.ams.api.model.amount import Amount
+from com.alipay.ams.api.model.quote import Quote
 
 
 
@@ -19,6 +21,8 @@ class Transaction:
         self.__transaction_request_id = None  # type: str
         self.__transaction_time = None  # type: str
         self.__acquirer_info = None  # type: AcquirerInfo
+        self.__gross_settlement_amount = None  # type: Amount
+        self.__settlement_quote = None  # type: Quote
         
 
     @property
@@ -101,6 +105,26 @@ class Transaction:
     @acquirer_info.setter
     def acquirer_info(self, value):
         self.__acquirer_info = value
+    @property
+    def gross_settlement_amount(self):
+        """Gets the gross_settlement_amount of this Transaction.
+        
+        """
+        return self.__gross_settlement_amount
+
+    @gross_settlement_amount.setter
+    def gross_settlement_amount(self, value):
+        self.__gross_settlement_amount = value
+    @property
+    def settlement_quote(self):
+        """Gets the settlement_quote of this Transaction.
+        
+        """
+        return self.__settlement_quote
+
+    @settlement_quote.setter
+    def settlement_quote(self, value):
+        self.__settlement_quote = value
 
 
     
@@ -123,6 +147,10 @@ class Transaction:
             params['transactionTime'] = self.transaction_time
         if hasattr(self, "acquirer_info") and self.acquirer_info is not None:
             params['acquirerInfo'] = self.acquirer_info
+        if hasattr(self, "gross_settlement_amount") and self.gross_settlement_amount is not None:
+            params['grossSettlementAmount'] = self.gross_settlement_amount
+        if hasattr(self, "settlement_quote") and self.settlement_quote is not None:
+            params['settlementQuote'] = self.settlement_quote
         return params
 
 
@@ -150,3 +178,9 @@ class Transaction:
         if 'acquirerInfo' in response_body:
             self.__acquirer_info = AcquirerInfo()
             self.__acquirer_info.parse_rsp_body(response_body['acquirerInfo'])
+        if 'grossSettlementAmount' in response_body:
+            self.__gross_settlement_amount = Amount()
+            self.__gross_settlement_amount.parse_rsp_body(response_body['grossSettlementAmount'])
+        if 'settlementQuote' in response_body:
+            self.__settlement_quote = Quote()
+            self.__settlement_quote.parse_rsp_body(response_body['settlementQuote'])

--- a/com/alipay/ams/api/model/transaction_type.py
+++ b/com/alipay/ams/api/model/transaction_type.py
@@ -9,6 +9,7 @@ class TransactionType(Enum):
     CANCEL = "CANCEL"
     AUTHORIZATION = "AUTHORIZATION"
     VOID = "VOID"
+    INCREMENTAL = "INCREMENTAL"
 
     def to_ams_dict(self) -> str:
         return self.name
@@ -30,4 +31,6 @@ class TransactionType(Enum):
             return TransactionType.AUTHORIZATION
         if TransactionType.VOID.value == value:
             return TransactionType.VOID
+        if TransactionType.INCREMENTAL.value == value:
+            return TransactionType.INCREMENTAL
         return None

--- a/com/alipay/ams/api/request/notify/alipay_pay_result_notify.py
+++ b/com/alipay/ams/api/request/notify/alipay_pay_result_notify.py
@@ -25,6 +25,8 @@ class AlipayPayResultNotify(AlipayNotify):
         self.__subscriptionOrderId = None
         self.__subscription_id = None # type: str
         self.__retry_info = None # type: RetryInfo
+        self.__update_request_id = None  # type: str
+        self.__auth_expiry_time = None  # type: str
         self.__parse_notify_body(notify_body)
 
     @property
@@ -102,6 +104,22 @@ class AlipayPayResultNotify(AlipayNotify):
     def retry_info(self, value):
         self.__retry_info = value
 
+    @property
+    def update_request_id(self):
+        return self.__update_request_id
+
+    @update_request_id.setter
+    def update_request_id(self, value):
+        self.__update_request_id = value
+
+    @property
+    def auth_expiry_time(self):
+        return self.__auth_expiry_time
+
+    @auth_expiry_time.setter
+    def auth_expiry_time(self, value):
+        self.__auth_expiry_time = value
+
     def __parse_notify_body(self, notify_body):
         notify = super(AlipayPayResultNotify, self).parse_notify_body(notify_body)
         if "paymentRequestId" in notify:
@@ -139,3 +157,7 @@ class AlipayPayResultNotify(AlipayNotify):
             self.__subscriptionOrderId = notify["subscriptionOrderId"]
         if "retryInfo" in notify:
             self.__retry_info = notify["retryInfo"]
+        if "updateRequestId" in notify:
+            self.__update_request_id = notify["updateRequestId"]
+        if "authExpiryTime" in notify:
+            self.__auth_expiry_time = notify["authExpiryTime"]

--- a/com/alipay/ams/api/request/pay/alipay_update_amount_request.py
+++ b/com/alipay/ams/api/request/pay/alipay_update_amount_request.py
@@ -1,0 +1,74 @@
+import json
+from com.alipay.ams.api.model.amount import Amount
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AlipayUpdateAmountRequest(AlipayRequest):
+    def __init__(self):
+        super(AlipayUpdateAmountRequest, self).__init__("/ams/api/v1/payments/updateAmount") 
+
+        self.__update_request_id = None  # type: str
+        self.__payment_id = None  # type: str
+        self.__amount = None  # type: Amount
+        
+
+    @property
+    def update_request_id(self):
+        """
+        The unique ID that is assigned by the merchant to identify an updateAmount request. Antom uses this field for idempotence control.  More information: Maximum length: 64 characters
+        """
+        return self.__update_request_id
+
+    @update_request_id.setter
+    def update_request_id(self, value):
+        self.__update_request_id = value
+    @property
+    def payment_id(self):
+        """
+        The unique ID that is assigned by Antom to identify a payment. The value of this parameter is the paymentId returned from the first pre-auth. More information: Maximum length: 64 characters
+        """
+        return self.__payment_id
+
+    @payment_id.setter
+    def payment_id(self, value):
+        self.__payment_id = value
+    @property
+    def amount(self):
+        """Gets the amount of this AlipayUpdateAmountRequest.
+        
+        """
+        return self.__amount
+
+    @amount.setter
+    def amount(self, value):
+        self.__amount = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "update_request_id") and self.update_request_id is not None:
+            params['updateRequestId'] = self.update_request_id
+        if hasattr(self, "payment_id") and self.payment_id is not None:
+            params['paymentId'] = self.payment_id
+        if hasattr(self, "amount") and self.amount is not None:
+            params['amount'] = self.amount
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'updateRequestId' in response_body:
+            self.__update_request_id = response_body['updateRequestId']
+        if 'paymentId' in response_body:
+            self.__payment_id = response_body['paymentId']
+        if 'amount' in response_body:
+            self.__amount = Amount()
+            self.__amount.parse_rsp_body(response_body['amount'])

--- a/com/alipay/ams/api/request/pay/ams_api_v1_payments_update_amount_post_request.py
+++ b/com/alipay/ams/api/request/pay/ams_api_v1_payments_update_amount_post_request.py
@@ -1,0 +1,74 @@
+import json
+from com.alipay.ams.api.model.amount import Amount
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AmsApiV1PaymentsUpdateAmountPostRequest(AlipayRequest):
+    def __init__(self):
+        super(AmsApiV1PaymentsUpdateAmountPostRequest, self).__init__("/ams/api/v1/payments/updateAmount") 
+
+        self.__update_request_id = None  # type: str
+        self.__payment_id = None  # type: str
+        self.__amount = None  # type: Amount
+        
+
+    @property
+    def update_request_id(self):
+        """
+        The unique ID that is assigned by the merchant to identify an updateAmount request. Antom uses this field for idempotence control. More information: Maximum length: 64 characters
+        """
+        return self.__update_request_id
+
+    @update_request_id.setter
+    def update_request_id(self, value):
+        self.__update_request_id = value
+    @property
+    def payment_id(self):
+        """
+        The unique ID that is assigned by Antom to identify a payment. The value of this parameter is the paymentId returned from the first pre-auth. More information: Maximum length: 64 characters
+        """
+        return self.__payment_id
+
+    @payment_id.setter
+    def payment_id(self, value):
+        self.__payment_id = value
+    @property
+    def amount(self):
+        """Gets the amount of this AmsApiV1PaymentsUpdateAmountPostRequest.
+        
+        """
+        return self.__amount
+
+    @amount.setter
+    def amount(self, value):
+        self.__amount = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "update_request_id") and self.update_request_id is not None:
+            params['updateRequestId'] = self.update_request_id
+        if hasattr(self, "payment_id") and self.payment_id is not None:
+            params['paymentId'] = self.payment_id
+        if hasattr(self, "amount") and self.amount is not None:
+            params['amount'] = self.amount
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'updateRequestId' in response_body:
+            self.__update_request_id = response_body['updateRequestId']
+        if 'paymentId' in response_body:
+            self.__payment_id = response_body['paymentId']
+        if 'amount' in response_body:
+            self.__amount = Amount()
+            self.__amount.parse_rsp_body(response_body['amount'])

--- a/com/alipay/ams/api/response/pay/alipay_update_amount_response.py
+++ b/com/alipay/ams/api/response/pay/alipay_update_amount_response.py
@@ -1,0 +1,88 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.amount import Amount
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AlipayUpdateAmountResponse(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__update_request_id = None  # type: str
+        self.__payment_id = None  # type: str
+        self.__amount = None  # type: Amount
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AlipayUpdateAmountResponse.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def update_request_id(self):
+        """
+        The unique ID that is assigned by the merchant to identify an updateAmount request. More information: Maximum length: 64 characters
+        """
+        return self.__update_request_id
+
+    @update_request_id.setter
+    def update_request_id(self, value):
+        self.__update_request_id = value
+    @property
+    def payment_id(self):
+        """
+        The unique ID that is assigned by Antom to identify a payment.  More information: Maximum length: 64 characters
+        """
+        return self.__payment_id
+
+    @payment_id.setter
+    def payment_id(self, value):
+        self.__payment_id = value
+    @property
+    def amount(self):
+        """Gets the amount of this AlipayUpdateAmountResponse.
+        
+        """
+        return self.__amount
+
+    @amount.setter
+    def amount(self, value):
+        self.__amount = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "update_request_id") and self.update_request_id is not None:
+            params['updateRequestId'] = self.update_request_id
+        if hasattr(self, "payment_id") and self.payment_id is not None:
+            params['paymentId'] = self.payment_id
+        if hasattr(self, "amount") and self.amount is not None:
+            params['amount'] = self.amount
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AlipayUpdateAmountResponse, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'updateRequestId' in response_body:
+            self.__update_request_id = response_body['updateRequestId']
+        if 'paymentId' in response_body:
+            self.__payment_id = response_body['paymentId']
+        if 'amount' in response_body:
+            self.__amount = Amount()
+            self.__amount.parse_rsp_body(response_body['amount'])

--- a/com/alipay/ams/api/response/pay/ams_api_v1_payments_update_amount_post200_response.py
+++ b/com/alipay/ams/api/response/pay/ams_api_v1_payments_update_amount_post200_response.py
@@ -1,0 +1,88 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.amount import Amount
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AmsApiV1PaymentsUpdateAmountPost200Response(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__update_request_id = None  # type: str
+        self.__payment_id = None  # type: str
+        self.__amount = None  # type: Amount
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AmsApiV1PaymentsUpdateAmountPost200Response.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def update_request_id(self):
+        """
+        The unique ID that is assigned by the merchant to identify an updateAmount request. More information: Maximum length: 64 characters
+        """
+        return self.__update_request_id
+
+    @update_request_id.setter
+    def update_request_id(self, value):
+        self.__update_request_id = value
+    @property
+    def payment_id(self):
+        """
+        The unique ID that is assigned by Antom to identify a payment. More information: Maximum length: 64 characters
+        """
+        return self.__payment_id
+
+    @payment_id.setter
+    def payment_id(self, value):
+        self.__payment_id = value
+    @property
+    def amount(self):
+        """Gets the amount of this AmsApiV1PaymentsUpdateAmountPost200Response.
+        
+        """
+        return self.__amount
+
+    @amount.setter
+    def amount(self, value):
+        self.__amount = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "update_request_id") and self.update_request_id is not None:
+            params['updateRequestId'] = self.update_request_id
+        if hasattr(self, "payment_id") and self.payment_id is not None:
+            params['paymentId'] = self.payment_id
+        if hasattr(self, "amount") and self.amount is not None:
+            params['amount'] = self.amount
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AmsApiV1PaymentsUpdateAmountPost200Response, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'updateRequestId' in response_body:
+            self.__update_request_id = response_body['updateRequestId']
+        if 'paymentId' in response_body:
+            self.__payment_id = response_body['paymentId']
+        if 'amount' in response_body:
+            self.__amount = Amount()
+            self.__amount.parse_rsp_body(response_body['amount'])


### PR DESCRIPTION
Add updateRequestId and authExpiryTime fields to AlipayPayResultNotify for UPDATE_AMOUNT_RESULT notify type.

This PR includes:
- Auto-generated code from sdk-automation/20260723-0240 (PaymentResultInfo +3 boolean, Transaction +2 fields, TransactionType +INCREMENTAL, UpdateAmount request/response)
- Manual notify changes: AlipayPayResultNotify +updateRequestId, +authExpiryTime

Source: https://yuque.antfin.com/zmskft/zxbox1/zbf5m2n3623banql