### PR TITLE
feat: add SDK version to user agent (release 1.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：Python  
 Python version：2.7+  
-Releass ^1.4.40
+Release ^1.5.2
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/ams/api/_version.py
+++ b/com/alipay/ams/api/_version.py
@@ -1,0 +1,2 @@
+VERSION = "1.5.2"
+USER_AGENT = "global-open-sdk-python/" + VERSION

--- a/com/alipay/ams/api/default_alipay_client.py
+++ b/com/alipay/ams/api/default_alipay_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from com.alipay.ams.api._version import USER_AGENT
 from com.alipay.ams.api.tools.signature_tool import *
 from com.alipay.ams.api.tools.date_tools import *
 from com.alipay.ams.api.net.default_http_rpc import *
@@ -113,7 +114,7 @@ class DefaultAlipayClient(object):
             "Accept": "text/plain,text/xml,text/javascript,text/html",
             "Cache-Control": "no-cache",
             "Connection": "Keep-Alive",
-            "User-Agent": "global-alipay-sdk-python",
+            "User-Agent": USER_AGENT,
             "Request-Time": req_time,
             "client-id": client_id,
             "Signature": signature,
@@ -138,7 +139,14 @@ class DefaultAlipayClient(object):
 
         return rsp_body
 
-    _RESERVED_HEADERS = {"signature", "client-id", "request-time", "content-type", "agent-token"}
+    _RESERVED_HEADERS = {
+        "signature",
+        "client-id",
+        "request-time",
+        "content-type",
+        "agent-token",
+        "user-agent",
+    }
     _SANDBOX_PRODUCTION_PATH_PREFIXES = (
         "/ams/api/v1/billing/",
         "/ams/api/v1/meter/",
@@ -171,7 +179,7 @@ class DefaultAlipayClient(object):
             "Accept": "text/plain,text/xml,text/javascript,text/html",
             "Cache-Control": "no-cache",
             "Connection": "Keep-Alive",
-            "User-Agent": "global-alipay-sdk-python",
+            "User-Agent": USER_AGENT,
             "Request-Time": req_time,
             "client-id": client_id,
             "Signature": signature,

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION=$1
+if ! printf '%s\n' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+  echo "Version must use stable SemVer format X.Y.Z: $VERSION" >&2
+  exit 1
+fi
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+python3 - "$ROOT_DIR" "$VERSION" <<'PY'
+import os
+import re
+import sys
+import tempfile
+
+root, version = sys.argv[1:3]
+
+
+def replace_once(relative_path, pattern, replacement):
+    path = os.path.join(root, relative_path)
+    with open(path, "r", encoding="utf-8", newline="") as source:
+        content = source.read()
+    updated, count = re.subn(pattern, replacement, content, count=1)
+    if count != 1:
+        raise SystemExit("Expected exactly one version field in {}".format(relative_path))
+    directory = os.path.dirname(path)
+    descriptor, temporary = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as target:
+            target.write(updated)
+        os.chmod(temporary, os.stat(path).st_mode)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+replace_once(
+    "com/alipay/ams/api/_version.py",
+    r'(?m)^VERSION = "[^"]+"$',
+    'VERSION = "{}"'.format(version),
+)
+replace_once(
+    "README.md",
+    r"(?m)^(?:Releass|Release) \^[^\r\n]+$",
+    "Release ^{}".format(version),
+)
+PY
+
+echo "Updated global-open-sdk-python to $VERSION"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
    [metadata]
    name = global-alipay-sdk-python
-   version = 1.5.1
 
    [options]
    packages = find:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
+from com.alipay.ams.api._version import VERSION
 
 """
 setup module for core.
@@ -12,7 +13,6 @@ DESCRIPTION = "The global alipay gateway SDK for Python."
 AUTHOR = "guodong.wzj"
 AUTHOR_EMAIL = "wangzunjiao.wzj@digital-engine.com"
 URL = "https://github.com/alipay/global-open-sdk-python"
-VERSION = "1.5.1"
 """
 only python2 need enum34、pytz
 """


### PR DESCRIPTION
## Summary
- Add unified SDK version identification via `User-Agent: global-open-sdk-python/{version}`
- Single version source: `com/alipay/ams/api/_version.py` (`setup.py` imports it; version removed from `setup.cfg`)
- Add `scripts/set-version.sh` as the unified version setter
- Bump version 1.5.1 → 1.5.2

Design doc: https://yuque.antfin.com/global-aquire/eibet3/ie54rtdm7fx24g6d