### PR TITLE
release: bump version to 1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：Python  
 Python version：2.7+  
-Release ^1.5.3
+Release ^1.5.4
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/ams/api/_version.py
+++ b/com/alipay/ams/api/_version.py
@@ -1,2 +1,2 @@
-VERSION = "1.5.3"
+VERSION = "1.5.4"
 USER_AGENT = "global-open-sdk-python/" + VERSION


### PR DESCRIPTION
## Summary
- bump Python SDK version from 1.5.3 to 1.5.4
- update the release version in README

## Verification
- built wheel and sdist with `python3 setup.py sdist bdist_wheel`
- `twine check dist/*` passed
- verified wheel and sdist contain no case-only path collisions
- installed and imported both local artifacts in isolated environments
- published `global-open-sdk-python==1.5.4` to PyPI
- verified PyPI artifact SHA-256 values match local artifacts
- installed `1.5.4` from the public PyPI Simple Index
- verified User-Agent `global-open-sdk-python/1.5.4`

## Known warning
- Generated docstrings containing `\&` continue to emit existing Python 3.13 `SyntaxWarning` messages; compilation, packaging, installation, and imports succeed.