### PR TITLE
Update all services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+  - Add the HTTP/2 session transport required by `meter/uploadEvent`.
+  - `meter/uploadEvent` requires Python 3.9 or later and the optional `http2` dependencies. Install the SDK with `pip install "global-open-sdk-python[http2]"`. Other SDK APIs retain the existing Python compatibility.
+
 ## 1.4.21 - 2025-12-01
   - update20251201
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,31 @@ Release ^1.5.4
 Copyright：Ant financial services group  
 ```
 
+#### Meter event upload
+
+Install the optional HTTP/2 dependencies. This API requires Python 3.9 or later;
+other SDK APIs retain the package's existing Python compatibility.
+
+```bash
+pip install "global-open-sdk-python[http2]"
+```
+
+`meter/createSession` uses the regular signed AMS transport. Use its session ID
+to call `meter/uploadEvent` through `execute_with_headers`:
+
+```python
+# Requires Python 3.9+ and: pip install "global-open-sdk-python[http2]"
+request = AlipayMeterUploadEventRequest()
+request.meters = meters
+response_body = default_alipay_client.execute_with_headers(
+    request, {"X-Session-Id": session_id}
+)
+```
+
+The SDK sends `meter/uploadEvent` to the gateway URL configured on the client,
+without sandbox path rewriting, request signing, response signature verification,
+or automatic retries. This API requires HTTP/2.
+
 #### 1 The sample for pay 
 ```
 from com.alipay.ams.api.model.merchant import Merchant

--- a/com/alipay/ams/api/default_alipay_client.py
+++ b/com/alipay/ams/api/default_alipay_client.py
@@ -5,6 +5,7 @@ from com.alipay.ams.api._version import USER_AGENT
 from com.alipay.ams.api.tools.signature_tool import *
 from com.alipay.ams.api.tools.date_tools import *
 from com.alipay.ams.api.net.default_http_rpc import *
+from com.alipay.ams.api.request_transport_resolver import requires_session_http2
 
 
 class DefaultAlipayClient(object):
@@ -179,10 +180,19 @@ class DefaultAlipayClient(object):
         if not hasattr(request, "path") or not request.path:
             raise AlipayApiException("invalid path")
 
+        http_method = request.http_method.value
+        if requires_session_http2(http_method, request.path):
+            from com.alipay.ams.api.session_http2_executor import (
+                execute_session_http2,
+            )
+
+            return execute_session_http2(
+                self.__gateway_url, request, extra_headers
+            )
+
         client_id = self.__client_id
         self.__is_sandbox_mode = client_id.startswith("SANDBOX_")
         self.adjust_sandbox_url(request)
-        http_method = request.http_method.value
         path = request.path
         req_time = get_cur_iso8601_time()
         req_body = request.to_ams_json()

--- a/com/alipay/ams/api/net/http2_json_transport.py
+++ b/com/alipay/ams/api/net/http2_json_transport.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+try:
+    import urllib.parse as url_parse
+except ImportError:
+    import urlparse as url_parse
+
+from com.alipay.ams.api._version import USER_AGENT
+from com.alipay.ams.api.exception.exception import AlipayApiException
+
+
+def post_http2_json(gateway_url, path, session_id, request_body):
+    if sys.version_info < (3, 9):
+        raise AlipayApiException(
+            "This API requires Python 3.9 or later and the SDK http2 extra"
+        )
+    try:
+        import h2  # noqa: F401
+        import httpx
+    except ImportError:
+        raise AlipayApiException(
+            "This API requires the optional HTTP/2 dependency. "
+            "Install global-open-sdk-python[http2]."
+        )
+
+    request_url = _build_request_url(gateway_url, path)
+    transport = httpx.HTTPTransport(http1=False, http2=True, retries=0)
+    try:
+        with httpx.Client(
+            transport=transport,
+            follow_redirects=False,
+            timeout=httpx.Timeout(30.0, connect=15.0),
+        ) as client:
+            client.headers.clear()
+            response = client.post(
+                request_url,
+                content=request_body.encode("utf-8"),
+                headers={
+                    "X-Session-Id": session_id,
+                    "Content-Type": "application/json; charset=UTF-8",
+                    "Accept": "application/json",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise AlipayApiException("HTTP/2 request failed: " + str(exc))
+
+    if response.http_version != "HTTP/2":
+        raise AlipayApiException(
+            "This API requires HTTP/2, but negotiated protocol was "
+            + response.http_version
+        )
+    if response.status_code != 200:
+        raise AlipayApiException(
+            "Response data error, HTTP status={0}, rspBody:{1}".format(
+                response.status_code, response.text
+            )
+        )
+    return response.text
+
+
+def _build_request_url(gateway_url, path):
+    parsed = url_parse.urlparse(gateway_url.strip())
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in ("", "/")
+    ):
+        raise AlipayApiException(
+            "gateway_url must be an HTTPS origin without path, query, "
+            "fragment, or user info"
+        )
+    if not path or not path.startswith("/"):
+        raise AlipayApiException("path must start with /")
+    port = ":{0}".format(parsed.port) if parsed.port else ""
+    return "https://{0}{1}{2}".format(parsed.hostname, port, path)

--- a/com/alipay/ams/api/request/billing/alipay_meter_upload_event_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_meter_upload_event_request.py
@@ -6,6 +6,13 @@ from com.alipay.ams.api.model.meter_event_batch import MeterEventBatch
 from com.alipay.ams.api.request.alipay_request import AlipayRequest
 
 class AlipayMeterUploadEventRequest(AlipayRequest):
+    """Request for uploading meter events over HTTP/2.
+
+    This API requires Python 3.9 or later and the optional SDK ``http2``
+    dependencies. Install them with
+    ``pip install "global-open-sdk-python[http2]"``.
+    """
+
     def __init__(self):
         super(AlipayMeterUploadEventRequest, self).__init__("/ams/api/v1/meter/uploadEvent") 
 

--- a/com/alipay/ams/api/request_transport_resolver.py
+++ b/com/alipay/ams/api/request_transport_resolver.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+_SESSION_HTTP2_ROUTES = (
+    ("POST", "/ams/api/v1/meter/uploadEvent"),
+)
+
+
+def requires_session_http2(http_method, path):
+    method = http_method.upper() if http_method else ""
+    return (method, path) in _SESSION_HTTP2_ROUTES

--- a/com/alipay/ams/api/session_http2_executor.py
+++ b/com/alipay/ams/api/session_http2_executor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import json
+
+from com.alipay.ams.api.exception.exception import AlipayApiException
+from com.alipay.ams.api.net.http2_json_transport import post_http2_json
+
+
+_SESSION_HEADER = "X-Session-Id"
+
+
+def execute_session_http2(gateway_url, request, extra_headers):
+    session_id = _validate_and_get_session_id(extra_headers)
+    request_body = request.to_ams_json()
+    response_body = post_http2_json(
+        gateway_url, request.path, session_id, request_body
+    )
+    try:
+        response_data = json.loads(response_body)
+    except (TypeError, ValueError) as exc:
+        raise AlipayApiException("Invalid HTTP/2 response JSON: " + str(exc))
+    if not isinstance(response_data, dict) or not isinstance(
+        response_data.get("result"), dict
+    ):
+        raise AlipayApiException("Response data error: result field is null")
+    return response_body
+
+
+def _validate_and_get_session_id(extra_headers):
+    if extra_headers is None:
+        extra_headers = {}
+    if not hasattr(extra_headers, "items"):
+        raise AlipayApiException("extra_headers must be a mapping")
+
+    session_id = None
+    for name, value in extra_headers.items():
+        if not isinstance(name, str) or name.lower() != _SESSION_HEADER.lower():
+            raise AlipayApiException(
+                "Only X-Session-Id is supported for this API. Unsupported header: "
+                + str(name)
+            )
+        if session_id is not None:
+            raise AlipayApiException("X-Session-Id must be provided only once")
+        session_id = value
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise AlipayApiException("X-Session-Id cannot be null or blank")
+    if "\r" in session_id or "\n" in session_id:
+        raise AlipayApiException(
+            "X-Session-Id cannot contain CR or LF characters"
+        )
+    return session_id

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,12 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=requires,
+    extras_require={
+        "http2": [
+            "httpx>=0.27,<1; python_version >= '3.9'",
+            "h2>=4.3,<5; python_version >= '3.9'",
+        ],
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- add the HTTP/2 session transport required by `meter/uploadEvent`
- preserve the existing signed AMS transport for all other APIs
- document Python 3.9+ and the optional `[http2]` dependencies

## Validation
- built and installed the wheel with HTTP/2 extras in an isolated environment
- verified `meter/uploadEvent` against the SG gateway over HTTP/2
- verified ordinary `execute_with_headers` requests still use the signed AMS path
- verified the base package imports without the optional HTTP/2 dependencies
- ran Python compilation and diff checks