### PR TITLE
release: bump version to 1.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：Python  
 Python version：2.7+  
-Release ^1.5.4
+Release ^1.5.5
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/ams/api/_version.py
+++ b/com/alipay/ams/api/_version.py
@@ -1,2 +1,2 @@
-VERSION = "1.5.4"
+VERSION = "1.5.5"
 USER_AGENT = "global-open-sdk-python/" + VERSION


### PR DESCRIPTION
## Summary
- bump Python SDK version from 1.5.4 to 1.5.5
- update the release version in README
- prepare the accepted ABA card transaction and Meter uploadEvent HTTP/2 changes for release

## Verification
- built wheel and sdist with `python3 setup.py sdist bdist_wheel`
- `twine check` passed for the 1.5.5 wheel and sdist
- verified Git, wheel, and sdist contain no case-only path collisions
- installed both local artifacts with the `http2` extra in isolated environments
- verified version and User-Agent `global-open-sdk-python/1.5.5`
- verified Meter uploadEvent HTTP/2 and ABA critical imports
- Python Meter uploadEvent live HTTP/2 regression returned `S / SUCCESS` with zero event errors
- PyPI version `1.5.5` is unoccupied

## Known warnings
- Existing package metadata omits a long description and uses the legacy MIT license classifier; packaging and Twine validation succeed.