### PR TITLE
Update APIs and prepare Python SDK 1.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：Python  
 Python version：2.7+  
-Release ^1.5.5
+Release ^1.5.6
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/ams/api/_version.py
+++ b/com/alipay/ams/api/_version.py
@@ -1,2 +1,2 @@
-VERSION = "1.5.5"
+VERSION = "1.5.6"
 USER_AGENT = "global-open-sdk-python/" + VERSION

--- a/com/alipay/ams/api/model/authorization_control.py
+++ b/com/alipay/ams/api/model/authorization_control.py
@@ -14,6 +14,7 @@ class AuthorizationControl:
         self.__allowed_merchant_category_list = None  # type: [str]
         self.__allowed_auth_times = None  # type: int
         self.__allowed_currencies = None  # type: [str]
+        self.__payment_preference_currencies = None  # type: [str]
         self.__card_limit_detail = None  # type: CardLimitDetail
         self.__card_limit_info = None  # type: CardLimitInfo
         self.__refund_preference = None  # type: RefundPreference
@@ -70,6 +71,16 @@ class AuthorizationControl:
     def allowed_currencies(self, value):
         self.__allowed_currencies = value
     @property
+    def payment_preference_currencies(self):
+        """
+        An ordered list of ISO 4217 currency codes that defines the card-level balance-consumption priority. Only applyCard accepts this field in a request; do not send it to updateCard. For applyCard, the list must not contain duplicates and every currency must be supported by Antom. Omission, null, or an empty list configures no card-level preference. The field participates in requestId idempotency, and invalid values, more than 9 entries, duplicates, or capability-disabled use return PARAM_ILLEGAL. For inquireCardDetail, a configured list is returned in stored order; an enabled merchant without a card-level preference receives null, and a disabled merchant does not receive the field. For inquireCardSensitiveInfo, a whitelisted merchant receives the configured list, the child field is omitted when no card-level preference exists, and a non-whitelisted merchant does not receive the parent cardDetail object. The initially supported currencies are USD, EUR, GBP, HKD, AUD, CAD, CNH, JPY, and NZD; the supported set is configuration-driven and can change without an API contract change.
+        """
+        return self.__payment_preference_currencies
+
+    @payment_preference_currencies.setter
+    def payment_preference_currencies(self, value):
+        self.__payment_preference_currencies = value
+    @property
     def card_limit_detail(self):
         """Gets the card_limit_detail of this AuthorizationControl.
         
@@ -115,6 +126,8 @@ class AuthorizationControl:
             params['allowedAuthTimes'] = self.allowed_auth_times
         if hasattr(self, "allowed_currencies") and self.allowed_currencies is not None:
             params['allowedCurrencies'] = self.allowed_currencies
+        if hasattr(self, "payment_preference_currencies") and self.payment_preference_currencies is not None:
+            params['paymentPreferenceCurrencies'] = self.payment_preference_currencies
         if hasattr(self, "card_limit_detail") and self.card_limit_detail is not None:
             params['cardLimitDetail'] = self.card_limit_detail
         if hasattr(self, "card_limit_info") and self.card_limit_info is not None:
@@ -137,6 +150,8 @@ class AuthorizationControl:
             self.__allowed_auth_times = response_body['allowedAuthTimes']
         if 'allowedCurrencies' in response_body:
             self.__allowed_currencies = response_body['allowedCurrencies']
+        if 'paymentPreferenceCurrencies' in response_body:
+            self.__payment_preference_currencies = response_body['paymentPreferenceCurrencies']
         if 'cardLimitDetail' in response_body:
             self.__card_limit_detail = CardLimitDetail()
             self.__card_limit_detail.parse_rsp_body(response_body['cardLimitDetail'])

--- a/com/alipay/ams/api/model/billing_subscription_status_change.py
+++ b/com/alipay/ams/api/model/billing_subscription_status_change.py
@@ -1,0 +1,37 @@
+import json
+
+
+
+
+class BillingSubscriptionStatusChange:
+    def __init__(self):
+        
+        self.__action = None  # type: str
+        
+
+    @property
+    def action(self):
+        """
+        The subscription status change action. The currently supported value is PAUSE, which pauses payment collection and changes the subscription status from ACTIVE to PAUSED. To reactivate a paused subscription, call the resume subscription API. Maximum length: 10 characters.
+        """
+        return self.__action
+
+    @action.setter
+    def action(self, value):
+        self.__action = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "action") and self.action is not None:
+            params['action'] = self.action
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'action' in response_body:
+            self.__action = response_body['action']

--- a/com/alipay/ams/api/model/card_detail.py
+++ b/com/alipay/ams/api/model/card_detail.py
@@ -1,17 +1,13 @@
 import json
-from com.alipay.ams.api.model.result import Result
 from com.alipay.ams.api.model.authorization_control import AuthorizationControl
 from com.alipay.ams.api.model.cardholder_info import CardholderInfo
 
 
 
-from com.alipay.ams.api.response.alipay_response import AlipayResponse
 
-class AlipayInquireCardDetailResponse(AlipayResponse):
-    def __init__(self, rsp_body):
-        super(AlipayResponse, self).__init__() 
-
-        self.__result = None  # type: Result
+class CardDetail:
+    def __init__(self):
+        
         self.__asset_id = None  # type: str
         self.__card_nick_name = None  # type: str
         self.__card_status = None  # type: str
@@ -24,19 +20,8 @@ class AlipayInquireCardDetailResponse(AlipayResponse):
         self.__metadata = None  # type: {str: (str,)}
         self.__authorization_control = None  # type: AuthorizationControl
         self.__cardholderinfo = None  # type: CardholderInfo
-        self.parse_rsp_body(rsp_body) 
-
-
-    @property
-    def result(self):
-        """Gets the result of this AlipayInquireCardDetailResponse.
         
-        """
-        return self.__result
 
-    @result.setter
-    def result(self, value):
-        self.__result = value
     @property
     def asset_id(self):
         """
@@ -139,7 +124,7 @@ class AlipayInquireCardDetailResponse(AlipayResponse):
         self.__metadata = value
     @property
     def authorization_control(self):
-        """Gets the authorization_control of this AlipayInquireCardDetailResponse.
+        """Gets the authorization_control of this CardDetail.
         
         """
         return self.__authorization_control
@@ -149,7 +134,7 @@ class AlipayInquireCardDetailResponse(AlipayResponse):
         self.__authorization_control = value
     @property
     def cardholderinfo(self):
-        """Gets the cardholderinfo of this AlipayInquireCardDetailResponse.
+        """Gets the cardholderinfo of this CardDetail.
         
         """
         return self.__cardholderinfo
@@ -163,8 +148,6 @@ class AlipayInquireCardDetailResponse(AlipayResponse):
 
     def to_ams_dict(self):
         params = dict()
-        if hasattr(self, "result") and self.result is not None:
-            params['result'] = self.result
         if hasattr(self, "asset_id") and self.asset_id is not None:
             params['assetId'] = self.asset_id
         if hasattr(self, "card_nick_name") and self.card_nick_name is not None:
@@ -193,10 +176,8 @@ class AlipayInquireCardDetailResponse(AlipayResponse):
 
 
     def parse_rsp_body(self, response_body):
-        response_body = super(AlipayInquireCardDetailResponse, self).parse_rsp_body(response_body)
-        if 'result' in response_body:
-            self.__result = Result()
-            self.__result.parse_rsp_body(response_body['result'])
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
         if 'assetId' in response_body:
             self.__asset_id = response_body['assetId']
         if 'cardNickName' in response_body:

--- a/com/alipay/ams/api/model/funds_type.py
+++ b/com/alipay/ams/api/model/funds_type.py
@@ -1,0 +1,18 @@
+from enum import Enum, unique
+@unique
+class FundsType(Enum):
+    """The funds type. The current version supports COLLATERAL only."""
+
+    COLLATERAL = "COLLATERAL"
+
+    def to_ams_dict(self) -> str:
+        return self.name
+
+    @staticmethod
+    def value_of(value):
+        if not value:
+            return None
+
+        if FundsType.COLLATERAL.value == value:
+            return FundsType.COLLATERAL
+        return None

--- a/com/alipay/ams/api/model/paginator.py
+++ b/com/alipay/ams/api/model/paginator.py
@@ -15,7 +15,7 @@ class Paginator:
     @property
     def current_page(self):
         """
-        The current page number, start from 1.
+        The current page number, starting from 1.
         """
         return self.__current_page
 
@@ -25,7 +25,7 @@ class Paginator:
     @property
     def page_size(self):
         """
-        The maximum records returned per page.
+        The number of records returned per page.
         """
         return self.__page_size
 
@@ -35,7 +35,7 @@ class Paginator:
     @property
     def total_page(self):
         """
-        Total number of pages.
+        The total number of pages.
         """
         return self.__total_page
 
@@ -45,7 +45,7 @@ class Paginator:
     @property
     def total_count(self):
         """
-        Total items that match the criteria.
+        The total number of records that match the query criteria.
         """
         return self.__total_count
 

--- a/com/alipay/ams/api/model/payment_method_scope.py
+++ b/com/alipay/ams/api/model/payment_method_scope.py
@@ -1,0 +1,21 @@
+from enum import Enum, unique
+@unique
+class PaymentMethodScope(Enum):
+    """The payment method scope to which the reserve rule applies."""
+
+    ALL = "ALL"
+    CARD = "CARD"
+
+    def to_ams_dict(self) -> str:
+        return self.name
+
+    @staticmethod
+    def value_of(value):
+        if not value:
+            return None
+
+        if PaymentMethodScope.ALL.value == value:
+            return PaymentMethodScope.ALL
+        if PaymentMethodScope.CARD.value == value:
+            return PaymentMethodScope.CARD
+        return None

--- a/com/alipay/ams/api/model/release_type.py
+++ b/com/alipay/ams/api/model/release_type.py
@@ -1,0 +1,21 @@
+from enum import Enum, unique
+@unique
+class ReleaseType(Enum):
+    """The release schedule type. FIXED_TIME uses releaseTime and INTERVAL_TIME uses retentionTime."""
+
+    FIXED_TIME = "FIXED_TIME"
+    INTERVAL_TIME = "INTERVAL_TIME"
+
+    def to_ams_dict(self) -> str:
+        return self.name
+
+    @staticmethod
+    def value_of(value):
+        if not value:
+            return None
+
+        if ReleaseType.FIXED_TIME.value == value:
+            return ReleaseType.FIXED_TIME
+        if ReleaseType.INTERVAL_TIME.value == value:
+            return ReleaseType.INTERVAL_TIME
+        return None

--- a/com/alipay/ams/api/model/reserve_rule.py
+++ b/com/alipay/ams/api/model/reserve_rule.py
@@ -1,0 +1,212 @@
+import json
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.release_type import ReleaseType
+from com.alipay.ams.api.model.rule_status import RuleStatus
+
+
+
+
+class ReserveRule:
+    def __init__(self):
+        
+        self.__rule_id = None  # type: str
+        self.__merchant_id = None  # type: str
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_type = None  # type: ReleaseType
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        self.__rule_status = None  # type: RuleStatus
+        self.__create_time = None  # type: str
+        self.__update_time = None  # type: str
+        
+
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned positive numeric reserve rule identifier. Save and return this value unchanged for updates, cancellation, and cursor pagination. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+    @property
+    def merchant_id(self):
+        """
+        The ID of the merchant that owns the reserve rule. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__merchant_id
+
+    @merchant_id.setter
+    def merchant_id(self, value):
+        self.__merchant_id = value
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this ReserveRule.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this ReserveRule.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this ReserveRule.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The rolling reserve percentage. Returned when takeType is ROLLING and result.resultCode is SUCCESS.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this ReserveRule.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def release_time(self):
+        """
+        The fixed release instant as an ISO 8601 UTC string, for example 2026-12-31T16:00:00Z. Returned when releaseType is FIXED_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The rolling retention period in days. Returned when releaseType is INTERVAL_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+    @property
+    def rule_status(self):
+        """Gets the rule_status of this ReserveRule.
+        
+        """
+        return self.__rule_status
+
+    @rule_status.setter
+    def rule_status(self, value):
+        self.__rule_status = value
+    @property
+    def create_time(self):
+        """
+        The rule creation time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__create_time
+
+    @create_time.setter
+    def create_time(self, value):
+        self.__create_time = value
+    @property
+    def update_time(self):
+        """
+        The rule last-update time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__update_time
+
+    @update_time.setter
+    def update_time(self, value):
+        self.__update_time = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        if hasattr(self, "merchant_id") and self.merchant_id is not None:
+            params['merchantId'] = self.merchant_id
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        if hasattr(self, "rule_status") and self.rule_status is not None:
+            params['ruleStatus'] = self.rule_status
+        if hasattr(self, "create_time") and self.create_time is not None:
+            params['createTime'] = self.create_time
+        if hasattr(self, "update_time") and self.update_time is not None:
+            params['updateTime'] = self.update_time
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']
+        if 'merchantId' in response_body:
+            self.__merchant_id = response_body['merchantId']
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']
+        if 'ruleStatus' in response_body:
+            rule_status_temp = RuleStatus.value_of(response_body['ruleStatus'])
+            self.__rule_status = rule_status_temp
+        if 'createTime' in response_body:
+            self.__create_time = response_body['createTime']
+        if 'updateTime' in response_body:
+            self.__update_time = response_body['updateTime']

--- a/com/alipay/ams/api/model/rule_status.py
+++ b/com/alipay/ams/api/model/rule_status.py
@@ -1,0 +1,21 @@
+from enum import Enum, unique
+@unique
+class RuleStatus(Enum):
+    """The reserve rule configuration status. This status does not indicate whether retained funds have been released."""
+
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def to_ams_dict(self) -> str:
+        return self.name
+
+    @staticmethod
+    def value_of(value):
+        if not value:
+            return None
+
+        if RuleStatus.ACTIVE.value == value:
+            return RuleStatus.ACTIVE
+        if RuleStatus.DISABLED.value == value:
+            return RuleStatus.DISABLED
+        return None

--- a/com/alipay/ams/api/model/take_type.py
+++ b/com/alipay/ams/api/model/take_type.py
@@ -1,0 +1,18 @@
+from enum import Enum, unique
+@unique
+class TakeType(Enum):
+    """The collateral collection type. The current version supports ROLLING only."""
+
+    ROLLING = "ROLLING"
+
+    def to_ams_dict(self) -> str:
+        return self.name
+
+    @staticmethod
+    def value_of(value):
+        if not value:
+            return None
+
+        if TakeType.ROLLING.value == value:
+            return TakeType.ROLLING
+        return None

--- a/com/alipay/ams/api/model/tax_breakdown.py
+++ b/com/alipay/ams/api/model/tax_breakdown.py
@@ -18,7 +18,7 @@ class TaxBreakdown:
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 32 characters.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 

--- a/com/alipay/ams/api/model/tax_calculated_address.py
+++ b/com/alipay/ams/api/model/tax_calculated_address.py
@@ -1,0 +1,142 @@
+import json
+
+
+
+
+class TaxCalculatedAddress:
+    def __init__(self):
+        
+        self.__country = None  # type: str
+        self.__region = None  # type: str
+        self.__county = None  # type: str
+        self.__city = None  # type: str
+        self.__district = None  # type: str
+        self.__line1 = None  # type: str
+        self.__line2 = None  # type: str
+        self.__postal_code = None  # type: str
+        
+
+    @property
+    def country(self):
+        """
+        The country or region code. Maximum length: 2 characters.
+        """
+        return self.__country
+
+    @country.setter
+    def country(self, value):
+        self.__country = value
+    @property
+    def region(self):
+        """
+        The region. Maximum length: 10 characters.
+        """
+        return self.__region
+
+    @region.setter
+    def region(self, value):
+        self.__region = value
+    @property
+    def county(self):
+        """
+        The county. Maximum length: 64 characters.
+        """
+        return self.__county
+
+    @county.setter
+    def county(self, value):
+        self.__county = value
+    @property
+    def city(self):
+        """
+        The city. Maximum length: 64 characters.
+        """
+        return self.__city
+
+    @city.setter
+    def city(self, value):
+        self.__city = value
+    @property
+    def district(self):
+        """
+        The district. Maximum length: 64 characters.
+        """
+        return self.__district
+
+    @district.setter
+    def district(self, value):
+        self.__district = value
+    @property
+    def line1(self):
+        """
+        The first address line. Maximum length: 256 characters.
+        """
+        return self.__line1
+
+    @line1.setter
+    def line1(self, value):
+        self.__line1 = value
+    @property
+    def line2(self):
+        """
+        The second address line. Maximum length: 256 characters.
+        """
+        return self.__line2
+
+    @line2.setter
+    def line2(self, value):
+        self.__line2 = value
+    @property
+    def postal_code(self):
+        """
+        The postal code. Maximum length: 16 characters.
+        """
+        return self.__postal_code
+
+    @postal_code.setter
+    def postal_code(self, value):
+        self.__postal_code = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "country") and self.country is not None:
+            params['country'] = self.country
+        if hasattr(self, "region") and self.region is not None:
+            params['region'] = self.region
+        if hasattr(self, "county") and self.county is not None:
+            params['county'] = self.county
+        if hasattr(self, "city") and self.city is not None:
+            params['city'] = self.city
+        if hasattr(self, "district") and self.district is not None:
+            params['district'] = self.district
+        if hasattr(self, "line1") and self.line1 is not None:
+            params['line1'] = self.line1
+        if hasattr(self, "line2") and self.line2 is not None:
+            params['line2'] = self.line2
+        if hasattr(self, "postal_code") and self.postal_code is not None:
+            params['postalCode'] = self.postal_code
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'country' in response_body:
+            self.__country = response_body['country']
+        if 'region' in response_body:
+            self.__region = response_body['region']
+        if 'county' in response_body:
+            self.__county = response_body['county']
+        if 'city' in response_body:
+            self.__city = response_body['city']
+        if 'district' in response_body:
+            self.__district = response_body['district']
+        if 'line1' in response_body:
+            self.__line1 = response_body['line1']
+        if 'line2' in response_body:
+            self.__line2 = response_body['line2']
+        if 'postalCode' in response_body:
+            self.__postal_code = response_body['postalCode']

--- a/com/alipay/ams/api/model/tax_calculated_business_details.py
+++ b/com/alipay/ams/api/model/tax_calculated_business_details.py
@@ -1,0 +1,39 @@
+import json
+from com.alipay.ams.api.model.tax_calculated_address import TaxCalculatedAddress
+
+
+
+
+class TaxCalculatedBusinessDetails:
+    def __init__(self):
+        
+        self.__address = None  # type: TaxCalculatedAddress
+        
+
+    @property
+    def address(self):
+        """Gets the address of this TaxCalculatedBusinessDetails.
+        
+        """
+        return self.__address
+
+    @address.setter
+    def address(self, value):
+        self.__address = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "address") and self.address is not None:
+            params['address'] = self.address
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'address' in response_body:
+            self.__address = TaxCalculatedAddress()
+            self.__address.parse_rsp_body(response_body['address'])

--- a/com/alipay/ams/api/model/tax_calculated_customer_details.py
+++ b/com/alipay/ams/api/model/tax_calculated_customer_details.py
@@ -1,26 +1,26 @@
 import json
-from com.alipay.ams.api.model.tax_business_details import TaxBusinessDetails
-from com.alipay.ams.api.model.tax_address import TaxAddress
-from com.alipay.ams.api.model.tax_address import TaxAddress
-from com.alipay.ams.api.model.tax_id import TaxId
-from com.alipay.ams.api.model.tax_exemption import TaxExemption
+from com.alipay.ams.api.model.tax_calculated_business_details import TaxCalculatedBusinessDetails
+from com.alipay.ams.api.model.tax_calculated_address import TaxCalculatedAddress
+from com.alipay.ams.api.model.tax_calculated_address import TaxCalculatedAddress
+from com.alipay.ams.api.model.tax_calculated_tax_id import TaxCalculatedTaxId
+from com.alipay.ams.api.model.tax_calculated_exemption import TaxCalculatedExemption
 
 
 
 
-class TaxCustomerDetails:
+class TaxCalculatedCustomerDetails:
     def __init__(self):
         
-        self.__business_details = None  # type: TaxBusinessDetails
-        self.__shipping_address = None  # type: TaxAddress
-        self.__billing_address = None  # type: TaxAddress
-        self.__tax_ids = None  # type: [TaxId]
-        self.__tax_exemptions = None  # type: [TaxExemption]
+        self.__business_details = None  # type: TaxCalculatedBusinessDetails
+        self.__shipping_address = None  # type: TaxCalculatedAddress
+        self.__billing_address = None  # type: TaxCalculatedAddress
+        self.__tax_ids = None  # type: [TaxCalculatedTaxId]
+        self.__tax_exemptions = None  # type: [TaxCalculatedExemption]
         
 
     @property
     def business_details(self):
-        """Gets the business_details of this TaxCustomerDetails.
+        """Gets the business_details of this TaxCalculatedCustomerDetails.
         
         """
         return self.__business_details
@@ -30,7 +30,7 @@ class TaxCustomerDetails:
         self.__business_details = value
     @property
     def shipping_address(self):
-        """Gets the shipping_address of this TaxCustomerDetails.
+        """Gets the shipping_address of this TaxCalculatedCustomerDetails.
         
         """
         return self.__shipping_address
@@ -40,7 +40,7 @@ class TaxCustomerDetails:
         self.__shipping_address = value
     @property
     def billing_address(self):
-        """Gets the billing_address of this TaxCustomerDetails.
+        """Gets the billing_address of this TaxCalculatedCustomerDetails.
         
         """
         return self.__billing_address
@@ -51,7 +51,7 @@ class TaxCustomerDetails:
     @property
     def tax_ids(self):
         """
-        The customer tax ID list. Maximum size: 10.
+        The effective customer tax ID list. Maximum size: 10.
         """
         return self.__tax_ids
 
@@ -61,7 +61,7 @@ class TaxCustomerDetails:
     @property
     def tax_exemptions(self):
         """
-        The customer tax exemption list. Maximum size: 10.
+        The effective customer tax exemption list. Maximum size: 10.
         """
         return self.__tax_exemptions
 
@@ -91,23 +91,23 @@ class TaxCustomerDetails:
         if isinstance(response_body, str): 
             response_body = json.loads(response_body)
         if 'businessDetails' in response_body:
-            self.__business_details = TaxBusinessDetails()
+            self.__business_details = TaxCalculatedBusinessDetails()
             self.__business_details.parse_rsp_body(response_body['businessDetails'])
         if 'shippingAddress' in response_body:
-            self.__shipping_address = TaxAddress()
+            self.__shipping_address = TaxCalculatedAddress()
             self.__shipping_address.parse_rsp_body(response_body['shippingAddress'])
         if 'billingAddress' in response_body:
-            self.__billing_address = TaxAddress()
+            self.__billing_address = TaxCalculatedAddress()
             self.__billing_address.parse_rsp_body(response_body['billingAddress'])
         if 'taxIds' in response_body:
             self.__tax_ids = []
             for item in response_body['taxIds']:
-                obj = TaxId()
+                obj = TaxCalculatedTaxId()
                 obj.parse_rsp_body(item)
                 self.__tax_ids.append(obj)
         if 'taxExemptions' in response_body:
             self.__tax_exemptions = []
             for item in response_body['taxExemptions']:
-                obj = TaxExemption()
+                obj = TaxCalculatedExemption()
                 obj.parse_rsp_body(item)
                 self.__tax_exemptions.append(obj)

--- a/com/alipay/ams/api/model/tax_calculated_exemption.py
+++ b/com/alipay/ams/api/model/tax_calculated_exemption.py
@@ -1,0 +1,69 @@
+import json
+from com.alipay.ams.api.model.tax_calculated_exemption_jurisdiction import TaxCalculatedExemptionJurisdiction
+
+
+
+
+class TaxCalculatedExemption:
+    def __init__(self):
+        
+        self.__certificate_number = None  # type: str
+        self.__exemption_type = None  # type: str
+        self.__jurisdiction = None  # type: TaxCalculatedExemptionJurisdiction
+        
+
+    @property
+    def certificate_number(self):
+        """
+        The tax exemption certificate number. Maximum length: 64 characters.
+        """
+        return self.__certificate_number
+
+    @certificate_number.setter
+    def certificate_number(self, value):
+        self.__certificate_number = value
+    @property
+    def exemption_type(self):
+        """
+        The tax exemption type. Maximum length: 32 characters.
+        """
+        return self.__exemption_type
+
+    @exemption_type.setter
+    def exemption_type(self, value):
+        self.__exemption_type = value
+    @property
+    def jurisdiction(self):
+        """Gets the jurisdiction of this TaxCalculatedExemption.
+        
+        """
+        return self.__jurisdiction
+
+    @jurisdiction.setter
+    def jurisdiction(self, value):
+        self.__jurisdiction = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "certificate_number") and self.certificate_number is not None:
+            params['certificateNumber'] = self.certificate_number
+        if hasattr(self, "exemption_type") and self.exemption_type is not None:
+            params['exemptionType'] = self.exemption_type
+        if hasattr(self, "jurisdiction") and self.jurisdiction is not None:
+            params['jurisdiction'] = self.jurisdiction
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'certificateNumber' in response_body:
+            self.__certificate_number = response_body['certificateNumber']
+        if 'exemptionType' in response_body:
+            self.__exemption_type = response_body['exemptionType']
+        if 'jurisdiction' in response_body:
+            self.__jurisdiction = TaxCalculatedExemptionJurisdiction()
+            self.__jurisdiction.parse_rsp_body(response_body['jurisdiction'])

--- a/com/alipay/ams/api/model/tax_calculated_exemption_jurisdiction.py
+++ b/com/alipay/ams/api/model/tax_calculated_exemption_jurisdiction.py
@@ -3,25 +3,15 @@ import json
 
 
 
-class TaxId:
+class TaxCalculatedExemptionJurisdiction:
     def __init__(self):
         
-        self.__value = None  # type: str
         self.__country = None  # type: str
         self.__region = None  # type: str
-        self.__name = None  # type: str
+        self.__city = None  # type: str
+        self.__effective_from = None  # type: str
         
 
-    @property
-    def value(self):
-        """
-        The value of the amount as a positive integer in the smallest currency unit. Maximum length: 64 characters.
-        """
-        return self.__value
-
-    @value.setter
-    def value(self, value):
-        self.__value = value
     @property
     def country(self):
         """
@@ -35,7 +25,7 @@ class TaxId:
     @property
     def region(self):
         """
-        The region. Maximum length: 10 characters. Note: See documentation for details.
+        The region. Maximum length: 10 characters.
         """
         return self.__region
 
@@ -43,40 +33,50 @@ class TaxId:
     def region(self, value):
         self.__region = value
     @property
-    def name(self):
+    def city(self):
         """
-        The customer name recorded for tax purposes. Maximum length: 128 characters.
+        The city. Maximum length: 64 characters.
         """
-        return self.__name
+        return self.__city
 
-    @name.setter
-    def name(self, value):
-        self.__name = value
+    @city.setter
+    def city(self, value):
+        self.__city = value
+    @property
+    def effective_from(self):
+        """
+        The time when the tax exemption becomes effective. Maximum length: 32 characters.
+        """
+        return self.__effective_from
+
+    @effective_from.setter
+    def effective_from(self, value):
+        self.__effective_from = value
 
 
     
 
     def to_ams_dict(self):
         params = dict()
-        if hasattr(self, "value") and self.value is not None:
-            params['value'] = self.value
         if hasattr(self, "country") and self.country is not None:
             params['country'] = self.country
         if hasattr(self, "region") and self.region is not None:
             params['region'] = self.region
-        if hasattr(self, "name") and self.name is not None:
-            params['name'] = self.name
+        if hasattr(self, "city") and self.city is not None:
+            params['city'] = self.city
+        if hasattr(self, "effective_from") and self.effective_from is not None:
+            params['effectiveFrom'] = self.effective_from
         return params
 
 
     def parse_rsp_body(self, response_body):
         if isinstance(response_body, str): 
             response_body = json.loads(response_body)
-        if 'value' in response_body:
-            self.__value = response_body['value']
         if 'country' in response_body:
             self.__country = response_body['country']
         if 'region' in response_body:
             self.__region = response_body['region']
-        if 'name' in response_body:
-            self.__name = response_body['name']
+        if 'city' in response_body:
+            self.__city = response_body['city']
+        if 'effectiveFrom' in response_body:
+            self.__effective_from = response_body['effectiveFrom']

--- a/com/alipay/ams/api/model/tax_calculated_line_item.py
+++ b/com/alipay/ams/api/model/tax_calculated_line_item.py
@@ -8,7 +8,6 @@ class TaxCalculatedLineItem:
     def __init__(self):
         
         self.__goods_reference_id = None  # type: str
-        self.__unit_amount = None  # type: str
         self.__amount = None  # type: str
         self.__quantity = None  # type: int
         self.__tax_code = None  # type: str
@@ -27,16 +26,6 @@ class TaxCalculatedLineItem:
     @goods_reference_id.setter
     def goods_reference_id(self, value):
         self.__goods_reference_id = value
-    @property
-    def unit_amount(self):
-        """
-        The unit amount. Maximum length: 19 characters.
-        """
-        return self.__unit_amount
-
-    @unit_amount.setter
-    def unit_amount(self, value):
-        self.__unit_amount = value
     @property
     def amount(self):
         """
@@ -105,8 +94,6 @@ class TaxCalculatedLineItem:
         params = dict()
         if hasattr(self, "goods_reference_id") and self.goods_reference_id is not None:
             params['goodsReferenceId'] = self.goods_reference_id
-        if hasattr(self, "unit_amount") and self.unit_amount is not None:
-            params['unitAmount'] = self.unit_amount
         if hasattr(self, "amount") and self.amount is not None:
             params['amount'] = self.amount
         if hasattr(self, "quantity") and self.quantity is not None:
@@ -127,8 +114,6 @@ class TaxCalculatedLineItem:
             response_body = json.loads(response_body)
         if 'goodsReferenceId' in response_body:
             self.__goods_reference_id = response_body['goodsReferenceId']
-        if 'unitAmount' in response_body:
-            self.__unit_amount = response_body['unitAmount']
         if 'amount' in response_body:
             self.__amount = response_body['amount']
         if 'quantity' in response_body:

--- a/com/alipay/ams/api/model/tax_calculated_ship_from_details.py
+++ b/com/alipay/ams/api/model/tax_calculated_ship_from_details.py
@@ -1,0 +1,39 @@
+import json
+from com.alipay.ams.api.model.tax_calculated_address import TaxCalculatedAddress
+
+
+
+
+class TaxCalculatedShipFromDetails:
+    def __init__(self):
+        
+        self.__address = None  # type: TaxCalculatedAddress
+        
+
+    @property
+    def address(self):
+        """Gets the address of this TaxCalculatedShipFromDetails.
+        
+        """
+        return self.__address
+
+    @address.setter
+    def address(self, value):
+        self.__address = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "address") and self.address is not None:
+            params['address'] = self.address
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'address' in response_body:
+            self.__address = TaxCalculatedAddress()
+            self.__address.parse_rsp_body(response_body['address'])

--- a/com/alipay/ams/api/model/tax_calculated_tax_id.py
+++ b/com/alipay/ams/api/model/tax_calculated_tax_id.py
@@ -3,7 +3,7 @@ import json
 
 
 
-class TaxId:
+class TaxCalculatedTaxId:
     def __init__(self):
         
         self.__value = None  # type: str
@@ -15,7 +15,7 @@ class TaxId:
     @property
     def value(self):
         """
-        The value of the amount as a positive integer in the smallest currency unit. Maximum length: 64 characters.
+        The customer tax ID value. Maximum length: 64 characters.
         """
         return self.__value
 
@@ -35,7 +35,7 @@ class TaxId:
     @property
     def region(self):
         """
-        The region. Maximum length: 10 characters. Note: See documentation for details.
+        The region. Maximum length: 10 characters.
         """
         return self.__region
 
@@ -45,7 +45,7 @@ class TaxId:
     @property
     def name(self):
         """
-        The customer name recorded for tax purposes. Maximum length: 128 characters.
+        The customer name recorded for tax purposes. Maximum length: 256 characters.
         """
         return self.__name
 

--- a/com/alipay/ams/api/model/tax_calculation_line_item.py
+++ b/com/alipay/ams/api/model/tax_calculation_line_item.py
@@ -7,7 +7,7 @@ class TaxCalculationLineItem:
     def __init__(self):
         
         self.__goods_reference_id = None  # type: str
-        self.__unit_amount = None  # type: str
+        self.__amount = None  # type: str
         self.__quantity = None  # type: int
         self.__tax_code = None  # type: str
         self.__product_id = None  # type: str
@@ -25,19 +25,19 @@ class TaxCalculationLineItem:
     def goods_reference_id(self, value):
         self.__goods_reference_id = value
     @property
-    def unit_amount(self):
+    def amount(self):
         """
-        The unit amount. Maximum length: 19 characters.
+        The total amount of the line item in the smallest currency unit. Maximum length: 19 characters.
         """
-        return self.__unit_amount
+        return self.__amount
 
-    @unit_amount.setter
-    def unit_amount(self, value):
-        self.__unit_amount = value
+    @amount.setter
+    def amount(self, value):
+        self.__amount = value
     @property
     def quantity(self):
         """
-        The quantity.
+        The quantity. Valid range: 1 to 10000.
         """
         return self.__quantity
 
@@ -82,8 +82,8 @@ class TaxCalculationLineItem:
         params = dict()
         if hasattr(self, "goods_reference_id") and self.goods_reference_id is not None:
             params['goodsReferenceId'] = self.goods_reference_id
-        if hasattr(self, "unit_amount") and self.unit_amount is not None:
-            params['unitAmount'] = self.unit_amount
+        if hasattr(self, "amount") and self.amount is not None:
+            params['amount'] = self.amount
         if hasattr(self, "quantity") and self.quantity is not None:
             params['quantity'] = self.quantity
         if hasattr(self, "tax_code") and self.tax_code is not None:
@@ -100,8 +100,8 @@ class TaxCalculationLineItem:
             response_body = json.loads(response_body)
         if 'goodsReferenceId' in response_body:
             self.__goods_reference_id = response_body['goodsReferenceId']
-        if 'unitAmount' in response_body:
-            self.__unit_amount = response_body['unitAmount']
+        if 'amount' in response_body:
+            self.__amount = response_body['amount']
         if 'quantity' in response_body:
             self.__quantity = response_body['quantity']
         if 'taxCode' in response_body:

--- a/com/alipay/ams/api/model/tax_exemption.py
+++ b/com/alipay/ams/api/model/tax_exemption.py
@@ -1,0 +1,69 @@
+import json
+from com.alipay.ams.api.model.tax_exemption_jurisdiction import TaxExemptionJurisdiction
+
+
+
+
+class TaxExemption:
+    def __init__(self):
+        
+        self.__certificate_number = None  # type: str
+        self.__exemption_type = None  # type: str
+        self.__jurisdiction = None  # type: TaxExemptionJurisdiction
+        
+
+    @property
+    def certificate_number(self):
+        """
+        The tax exemption certificate number. Maximum length: 64 characters.
+        """
+        return self.__certificate_number
+
+    @certificate_number.setter
+    def certificate_number(self, value):
+        self.__certificate_number = value
+    @property
+    def exemption_type(self):
+        """
+        The tax exemption type. Currently supported value: RESALE. Maximum length: 32 characters.
+        """
+        return self.__exemption_type
+
+    @exemption_type.setter
+    def exemption_type(self, value):
+        self.__exemption_type = value
+    @property
+    def jurisdiction(self):
+        """Gets the jurisdiction of this TaxExemption.
+        
+        """
+        return self.__jurisdiction
+
+    @jurisdiction.setter
+    def jurisdiction(self, value):
+        self.__jurisdiction = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "certificate_number") and self.certificate_number is not None:
+            params['certificateNumber'] = self.certificate_number
+        if hasattr(self, "exemption_type") and self.exemption_type is not None:
+            params['exemptionType'] = self.exemption_type
+        if hasattr(self, "jurisdiction") and self.jurisdiction is not None:
+            params['jurisdiction'] = self.jurisdiction
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'certificateNumber' in response_body:
+            self.__certificate_number = response_body['certificateNumber']
+        if 'exemptionType' in response_body:
+            self.__exemption_type = response_body['exemptionType']
+        if 'jurisdiction' in response_body:
+            self.__jurisdiction = TaxExemptionJurisdiction()
+            self.__jurisdiction.parse_rsp_body(response_body['jurisdiction'])

--- a/com/alipay/ams/api/model/tax_exemption_jurisdiction.py
+++ b/com/alipay/ams/api/model/tax_exemption_jurisdiction.py
@@ -3,25 +3,15 @@ import json
 
 
 
-class TaxId:
+class TaxExemptionJurisdiction:
     def __init__(self):
         
-        self.__value = None  # type: str
         self.__country = None  # type: str
         self.__region = None  # type: str
-        self.__name = None  # type: str
+        self.__city = None  # type: str
+        self.__effective_from = None  # type: str
         
 
-    @property
-    def value(self):
-        """
-        The value of the amount as a positive integer in the smallest currency unit. Maximum length: 64 characters.
-        """
-        return self.__value
-
-    @value.setter
-    def value(self, value):
-        self.__value = value
     @property
     def country(self):
         """
@@ -35,7 +25,7 @@ class TaxId:
     @property
     def region(self):
         """
-        The region. Maximum length: 10 characters. Note: See documentation for details.
+        The region. Maximum length: 10 characters.
         """
         return self.__region
 
@@ -43,40 +33,50 @@ class TaxId:
     def region(self, value):
         self.__region = value
     @property
-    def name(self):
+    def city(self):
         """
-        The customer name recorded for tax purposes. Maximum length: 128 characters.
+        The city. Maximum length: 64 characters.
         """
-        return self.__name
+        return self.__city
 
-    @name.setter
-    def name(self, value):
-        self.__name = value
+    @city.setter
+    def city(self, value):
+        self.__city = value
+    @property
+    def effective_from(self):
+        """
+        The time when the tax exemption becomes effective. Maximum length: 32 characters.
+        """
+        return self.__effective_from
+
+    @effective_from.setter
+    def effective_from(self, value):
+        self.__effective_from = value
 
 
     
 
     def to_ams_dict(self):
         params = dict()
-        if hasattr(self, "value") and self.value is not None:
-            params['value'] = self.value
         if hasattr(self, "country") and self.country is not None:
             params['country'] = self.country
         if hasattr(self, "region") and self.region is not None:
             params['region'] = self.region
-        if hasattr(self, "name") and self.name is not None:
-            params['name'] = self.name
+        if hasattr(self, "city") and self.city is not None:
+            params['city'] = self.city
+        if hasattr(self, "effective_from") and self.effective_from is not None:
+            params['effectiveFrom'] = self.effective_from
         return params
 
 
     def parse_rsp_body(self, response_body):
         if isinstance(response_body, str): 
             response_body = json.loads(response_body)
-        if 'value' in response_body:
-            self.__value = response_body['value']
         if 'country' in response_body:
             self.__country = response_body['country']
         if 'region' in response_body:
             self.__region = response_body['region']
-        if 'name' in response_body:
-            self.__name = response_body['name']
+        if 'city' in response_body:
+            self.__city = response_body['city']
+        if 'effectiveFrom' in response_body:
+            self.__effective_from = response_body['effectiveFrom']

--- a/com/alipay/ams/api/model/tax_registration.py
+++ b/com/alipay/ams/api/model/tax_registration.py
@@ -30,7 +30,7 @@ class TaxRegistration:
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 16 characters.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 
@@ -50,7 +50,7 @@ class TaxRegistration:
     @property
     def registration_type(self):
         """
-        The tax registration type. Maximum length: 32 characters.
+        The tax registration type. Supported values are OSS_NON_UNION, STANDARD_LOCAL_TAX, SINGLE_LOCAL_USE_TAX_RATE, SIMPLIFIED_SELLERS_USE_TAX, STANDARD_SALES_AND_USE_TAX, NORMAL_GST_HST, and SIMPLIFIED_GST_HST. Maximum length: 32 characters.
         """
         return self.__registration_type
 

--- a/com/alipay/ams/api/model/tax_transaction.py
+++ b/com/alipay/ams/api/model/tax_transaction.py
@@ -52,7 +52,7 @@ class TaxTransaction:
     @property
     def tax_amount(self):
         """
-        The tax amount. Maximum length: 19 characters.
+        The non-negative tax amount in the smallest currency unit, without leading zeros. For TRANSACTION and REVERSAL records, this value is always a positive absolute amount. Reconcile a business scope by subtracting the sum of REVERSAL amounts from the sum of TRANSACTION amounts. Maximum length: 19 characters.
         """
         return self.__tax_amount
 
@@ -62,7 +62,7 @@ class TaxTransaction:
     @property
     def currency(self):
         """
-        The 3-letter currency code that follows the ISO 4217 standard. Maximum length: 3 characters.
+        The 3-letter currency code that follows the ISO 4217 standard. This field is returned together with taxAmount. Maximum length: 3 characters.
         """
         return self.__currency
 

--- a/com/alipay/ams/api/request/billing/alipay_billing_subscription_inquire_list_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_billing_subscription_inquire_list_request.py
@@ -22,7 +22,7 @@ class AlipayBillingSubscriptionInquireListRequest(AlipayRequest):
     @property
     def status(self):
         """
-        The current status. Maximum length: 20 characters.
+        Filters subscriptions by status. To provide multiple values, use a comma-separated string such as ACTIVE,PAUSED. Up to eight values are supported. Valid values are INCOMPLETE, TRIALING, ACTIVE, PAST_DUE, PAUSED, CANCELLED, TERMINATED, and UNPAID. Each status value has a maximum length of 20 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/request/billing/alipay_billing_subscription_update_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_billing_subscription_update_request.py
@@ -1,6 +1,7 @@
 import json
 from com.alipay.ams.api.model.price_item_change import PriceItemChange
 from com.alipay.ams.api.model.billing_trial_settings import BillingTrialSettings
+from com.alipay.ams.api.model.billing_subscription_status_change import BillingSubscriptionStatusChange
 from com.alipay.ams.api.model.billing_subscription_cancellation_details import BillingSubscriptionCancellationDetails
 
 
@@ -16,6 +17,7 @@ class AlipayBillingSubscriptionUpdateRequest(AlipayRequest):
         self.__proration_behavior = None  # type: str
         self.__reset_billing_cycle_anchor = None  # type: bool
         self.__trial_settings = None  # type: BillingTrialSettings
+        self.__status_change = None  # type: BillingSubscriptionStatusChange
         self.__cancel_at_period_end = None  # type: bool
         self.__cancel_at = None  # type: str
         self.__cancellation_details = None  # type: BillingSubscriptionCancellationDetails
@@ -75,6 +77,16 @@ class AlipayBillingSubscriptionUpdateRequest(AlipayRequest):
     @trial_settings.setter
     def trial_settings(self, value):
         self.__trial_settings = value
+    @property
+    def status_change(self):
+        """Gets the status_change of this AlipayBillingSubscriptionUpdateRequest.
+        
+        """
+        return self.__status_change
+
+    @status_change.setter
+    def status_change(self, value):
+        self.__status_change = value
     @property
     def cancel_at_period_end(self):
         """
@@ -164,6 +176,8 @@ class AlipayBillingSubscriptionUpdateRequest(AlipayRequest):
             params['resetBillingCycleAnchor'] = self.reset_billing_cycle_anchor
         if hasattr(self, "trial_settings") and self.trial_settings is not None:
             params['trialSettings'] = self.trial_settings
+        if hasattr(self, "status_change") and self.status_change is not None:
+            params['statusChange'] = self.status_change
         if hasattr(self, "cancel_at_period_end") and self.cancel_at_period_end is not None:
             params['cancelAtPeriodEnd'] = self.cancel_at_period_end
         if hasattr(self, "cancel_at") and self.cancel_at is not None:
@@ -199,6 +213,9 @@ class AlipayBillingSubscriptionUpdateRequest(AlipayRequest):
         if 'trialSettings' in response_body:
             self.__trial_settings = BillingTrialSettings()
             self.__trial_settings.parse_rsp_body(response_body['trialSettings'])
+        if 'statusChange' in response_body:
+            self.__status_change = BillingSubscriptionStatusChange()
+            self.__status_change.parse_rsp_body(response_body['statusChange'])
         if 'cancelAtPeriodEnd' in response_body:
             self.__cancel_at_period_end = response_body['cancelAtPeriodEnd']
         if 'cancelAt' in response_body:

--- a/com/alipay/ams/api/request/billing/alipay_customer_create_portal_link_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_customer_create_portal_link_request.py
@@ -18,7 +18,7 @@ class AlipayCustomerCreatePortalLinkRequest(AlipayRequest):
     @property
     def customer_id(self):
         """
-        Customer ID to target. When both &#x60;customerId&#x60; and &#x60;email&#x60; are supplied, &#x60;customerId&#x60; takes precedence.
+        Customer ID to target. Either &#x60;customerId&#x60; or &#x60;email&#x60; must be provided. When both are provided, &#x60;email&#x60; must match the registered account email of this customer; otherwise, the API returns &#x60;PARAM_ILLEGAL&#x60;. Maximum length: 64 characters.
         """
         return self.__customer_id
 
@@ -28,7 +28,7 @@ class AlipayCustomerCreatePortalLinkRequest(AlipayRequest):
     @property
     def email(self):
         """
-        Customer email for lookup. When multiple customers share the email, the most recently created (by &#x60;gmtCreate DESC&#x60;) is selected. Maximum length: 254 characters (RFC 5322).
+        Customer email for lookup. Either &#x60;customerId&#x60; or &#x60;email&#x60; must be provided. When multiple customers share the email, the most recently created customer by &#x60;gmtCreate&#x60; descending is selected. When both fields are provided, this value must match the registered account email of the specified customer; otherwise, the API returns &#x60;PARAM_ILLEGAL&#x60;. Maximum length: 254 characters (RFC 5322).
         """
         return self.__email
 
@@ -38,7 +38,7 @@ class AlipayCustomerCreatePortalLinkRequest(AlipayRequest):
     @property
     def features(self):
         """
-        Feature set enabled for this portal session. Allowed values: &#x60;SUBSCRIPTION&#x60;, &#x60;INVOICE&#x60;, &#x60;PAYMENT_METHOD&#x60;. Empty/absent list -&gt; ALL features enabled by default (NOT an intersection with settingId features, as previously documented). The portal settings referenced by &#x60;settingId&#x60; may further restrict which features are shown at render time.
+        Feature set enabled for this portal session. Allowed values: &#x60;SUBSCRIPTION&#x60;, &#x60;INVOICE&#x60;, &#x60;PAYMENT_METHOD&#x60;. An empty or absent list enables all features by default. The portal settings referenced by &#x60;settingId&#x60; may further restrict which features are shown at render time. Maximum size: 3 elements.
         """
         return self.__features
 
@@ -58,7 +58,7 @@ class AlipayCustomerCreatePortalLinkRequest(AlipayRequest):
     @property
     def setting_id(self):
         """
-        Portal setting configuration ID. Passed through token payload, parsed by iexpfront.
+        Portal setting configuration ID passed through the token payload. Maximum length: 64 characters.
         """
         return self.__setting_id
 

--- a/com/alipay/ams/api/request/billing/alipay_customer_create_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_customer_create_request.py
@@ -303,7 +303,7 @@ class AlipayCustomerCreateRequest(AlipayRequest):
     @property
     def billing_email(self):
         """
-        Invoice recipient email address (independent of account &#x60;email&#x60;). Maximum length: 256 characters.
+        Email address used to receive bills and invoices. It can differ from the account &#x60;email&#x60;. If omitted during customer creation, it defaults to &#x60;email&#x60;. Maximum length: 256 characters.
         """
         return self.__billing_email
 

--- a/com/alipay/ams/api/request/billing/alipay_customer_update_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_customer_update_request.py
@@ -73,7 +73,7 @@ class AlipayCustomerUpdateRequest(AlipayRequest):
     @property
     def email(self):
         """
-        Updated email address. Optional - &#x60;null&#x60;/omitted means no change (PATCH semantics). No email-format validation is applied. Maximum length: 256 characters.
+        Updated account email address. Optional - &#x60;null&#x60; or omitted means no change (PATCH semantics). Updating this field does not change &#x60;billingEmail&#x60;, including when &#x60;billingEmail&#x60; originally defaulted from &#x60;email&#x60; during customer creation. No email-format validation is applied. Maximum length: 256 characters.
         """
         return self.__email
 
@@ -303,7 +303,7 @@ class AlipayCustomerUpdateRequest(AlipayRequest):
     @property
     def billing_email(self):
         """
-        Updated invoice recipient email. Maximum length: 256 characters.
+        Updated email address used to receive bills and invoices. Send this field explicitly when the invoice-recipient email must change; updating &#x60;email&#x60; alone does not change it. Maximum length: 256 characters.
         """
         return self.__billing_email
 

--- a/com/alipay/ams/api/request/billing/alipay_price_create_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_price_create_request.py
@@ -70,7 +70,7 @@ class AlipayPriceCreateRequest(AlipayRequest):
     @property
     def usage_type(self):
         """
-        Usage type. O - Optional. When provided, must be a valid enum value (LICENSED or METERED). Can be null; default null. Enum: LICENSED(fixed quantity billing - subscription item quantity is set at subscription creation and changed manually via update API; system bills unitAmount x quantity automatically each period), METERED(metered usage billing - quantity is tracked by external metering system iusage and reported via Usage Report API; system bills based on actual reported usage in arrears at end of billing period)
+        Usage type that identifies how subscription items are billed. Valid values are: &#x60;LICENSED&#x60; - fixed-quantity billing; the quantity is set when the subscription is created and can be changed through the update API, and &#x60;unitAmount&#x60; multiplied by &#x60;quantity&#x60; is billed each period. &#x60;METERED&#x60; - metered billing based on the actual usage quantity at the end of each billing period. Maximum length: 16 characters.
         """
         return self.__usage_type
 
@@ -100,7 +100,7 @@ class AlipayPriceCreateRequest(AlipayRequest):
     @property
     def meter_id(self):
         """
-        External meter reference. C - Required when usageType&#x3D;METERED; otherwise forbidden. References external metering system contract. Format: alphanumeric + underscore, max 32 chars. Validated at price creation: format check (regex: ^[a-zA-Z0-9_]{1,32}$) AND existence check against iusage meter registry. Returns METER_NOT_FOUND if meter definition does not exist in iusage. This ensures fail-fast validation - merchants are alerted to invalid meter references immediately rather than discovering the error at subscription creation time
+        Meter ID. Required when &#x60;usageType&#x60; is &#x60;METERED&#x60;; otherwise, it must not be provided. The value must match &#x60;^[a-zA-Z0-9_]{1,32}$&#x60; and must exist in the meter registry. The API returns &#x60;METER_NOT_FOUND&#x60; when the meter does not exist. Maximum length: 32 characters.
         """
         return self.__meter_id
 
@@ -160,7 +160,7 @@ class AlipayPriceCreateRequest(AlipayRequest):
     @property
     def default_price(self):
         """
-        Whether this price is the default price for the product. O - Optional. Only &#x60;true&#x60; is accepted; &#x60;false&#x60; or absent means the price is not the default. Only one price per product can be the default price - creating a new default price automatically un-defaults any previous default price of that product. Can be null; default null
+        Whether to set this price as the default price for the product. When provided, only &#x60;true&#x60; is accepted. The first price created for a product must be set as the default price; otherwise, the API returns &#x60;FIRST_PRICE_NOT_DEFAULT&#x60;. A product can have only one default price, and creating a new default price automatically removes the default status from the previous one.
         """
         return self.__default_price
 

--- a/com/alipay/ams/api/request/billing/alipay_price_update_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_price_update_request.py
@@ -58,7 +58,7 @@ class AlipayPriceUpdateRequest(AlipayRequest):
     @property
     def default_price(self):
         """
-        Whether this price is the default price for the product. O - Only &#x60;true&#x60; is accepted; &#x60;false&#x60; or absent means no change. When set to true, this price becomes the default price of the product and any previous default price of that product is automatically un-defaulted. Cannot be combined with active&#x3D;false in the same request - a default price must remain active
+        Whether to set this price as the default price for the product. When provided, only &#x60;true&#x60; is accepted; &#x60;false&#x60; is rejected with &#x60;DEFAULT_PRICE_REMOVAL_FORBIDDEN&#x60;, while omission means no change. When set to &#x60;true&#x60;, this price becomes the product default and the previous default price is automatically unset. &#x60;defaultPrice&#x3D;true&#x60; cannot be combined with &#x60;active&#x3D;false&#x60; in the same request because the default price must remain active. A product must always retain a default price.
         """
         return self.__default_price
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_cancel_registration_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_cancel_registration_request.py
@@ -15,7 +15,7 @@ class AlipayTaxCancelRegistrationRequest(AlipayRequest):
     @property
     def registration_cancel_request_id(self):
         """
-        The unique ID assigned by a merchant to identify a tax registration cancellation request. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by a merchant to identify a tax registration cancellation request. Any repeated request using an accepted ID returns REPEATED_SUBMIT. Maximum length: 64 characters.
         """
         return self.__registration_cancel_request_id
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_initialize_settings_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_initialize_settings_request.py
@@ -18,7 +18,7 @@ class AlipayTaxInitializeSettingsRequest(AlipayRequest):
     @property
     def settings_request_id(self):
         """
-        The unique ID assigned by a merchant to identify a tax settings initialization request. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by a merchant to identify a tax settings initialization request. Reuse it only with the original request body when recovering an unknown result. Maximum length: 64 characters.
         """
         return self.__settings_request_id
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_inquire_calculation_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_inquire_calculation_request.py
@@ -16,7 +16,7 @@ class AlipayTaxInquireCalculationRequest(AlipayRequest):
     @property
     def tax_calculation_id(self):
         """
-        The unique ID assigned by Antom to identify a tax calculation. Maximum length: 64 characters. Note: See documentation for details.
+        The tax calculation ID returned by a successful calculate request. Specify exactly one of taxCalculationId, taxCalculationRequestId, and paymentRequestId. Maximum length: 64 characters.
         """
         return self.__tax_calculation_id
 
@@ -26,7 +26,7 @@ class AlipayTaxInquireCalculationRequest(AlipayRequest):
     @property
     def tax_calculation_request_id(self):
         """
-        The unique ID assigned by a merchant to identify a tax calculation request. Maximum length: 64 characters. Note: See documentation for details.
+        The original tax calculation request ID. Use this field to recover an unknown, timed-out, or lost calculate response. Specify exactly one query key. Maximum length: 64 characters.
         """
         return self.__tax_calculation_request_id
 
@@ -36,7 +36,7 @@ class AlipayTaxInquireCalculationRequest(AlipayRequest):
     @property
     def payment_request_id(self):
         """
-        The unique ID assigned by a merchant to identify a payment request. Maximum length: 64 characters. Note: See documentation for details.
+        The payment request ID associated with the tax calculation. Use this field only when the payment references the calculation. Specify exactly one query key. Maximum length: 64 characters.
         """
         return self.__payment_request_id
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_inquire_transaction_list_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_inquire_transaction_list_request.py
@@ -18,7 +18,7 @@ class AlipayTaxInquireTransactionListRequest(AlipayRequest):
     @property
     def tax_calculation_id(self):
         """
-        The unique ID assigned by Antom to identify a tax calculation. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by Antom to identify a tax calculation. Exactly one of taxCalculationId, paymentId, and refundId must be provided. Omit the unused query keys; do not send them with null values. Maximum length: 64 characters.
         """
         return self.__tax_calculation_id
 
@@ -28,7 +28,7 @@ class AlipayTaxInquireTransactionListRequest(AlipayRequest):
     @property
     def payment_id(self):
         """
-        The unique ID assigned by Antom to identify a payment. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by Antom to identify a payment. Exactly one of taxCalculationId, paymentId, and refundId must be provided. Omit the unused query keys; do not send them with null values. Maximum length: 64 characters.
         """
         return self.__payment_id
 
@@ -38,7 +38,7 @@ class AlipayTaxInquireTransactionListRequest(AlipayRequest):
     @property
     def refund_id(self):
         """
-        The refund ID. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by Antom to identify a refund. Exactly one of taxCalculationId, paymentId, and refundId must be provided. Omit the unused query keys; do not send them with null values. Maximum length: 64 characters.
         """
         return self.__refund_id
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_register_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_register_request.py
@@ -21,7 +21,7 @@ class AlipayTaxRegisterRequest(AlipayRequest):
     @property
     def registration_request_id(self):
         """
-        The unique ID assigned by a merchant to identify a tax registration request. Maximum length: 64 characters. Note: See documentation for details.
+        The unique ID assigned by a merchant to identify a tax registration request. Once accepted, the ID is permanently occupied and any subsequent request using it returns REPEATED_SUBMIT. Maximum length: 64 characters.
         """
         return self.__registration_request_id
 
@@ -31,7 +31,7 @@ class AlipayTaxRegisterRequest(AlipayRequest):
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 16 characters.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 
@@ -51,7 +51,7 @@ class AlipayTaxRegisterRequest(AlipayRequest):
     @property
     def registration_type(self):
         """
-        The tax registration type. Maximum length: 32 characters.
+        The tax registration type. Supported values are OSS_NON_UNION, STANDARD_LOCAL_TAX, SINGLE_LOCAL_USE_TAX_RATE, SIMPLIFIED_SELLERS_USE_TAX, STANDARD_SALES_AND_USE_TAX, NORMAL_GST_HST, and SIMPLIFIED_GST_HST. Maximum length: 32 characters.
         """
         return self.__registration_type
 

--- a/com/alipay/ams/api/request/billing/alipay_tax_update_registration_period_request.py
+++ b/com/alipay/ams/api/request/billing/alipay_tax_update_registration_period_request.py
@@ -37,7 +37,7 @@ class AlipayTaxUpdateRegistrationPeriodRequest(AlipayRequest):
     @property
     def active_from(self):
         """
-        The time from which the tax registration is active. Maximum length: 32 characters. Note: See documentation for details.
+        The new activation time for a SCHEDULED registration. The value must be later than the current time. Maximum length: 32 characters.
         """
         return self.__active_from
 
@@ -47,7 +47,7 @@ class AlipayTaxUpdateRegistrationPeriodRequest(AlipayRequest):
     @property
     def expire_at(self):
         """
-        The expiration time. Maximum length: 32 characters. Note: See documentation for details.
+        The new expiration time for an ACTIVE or SCHEDULED registration. The value must be later than the current time and, for a scheduled registration, later than the effective activeFrom. Maximum length: 32 characters.
         """
         return self.__expire_at
 

--- a/com/alipay/ams/api/request/pay/alipay_cancel_rule_request.py
+++ b/com/alipay/ams/api/request/pay/alipay_cancel_rule_request.py
@@ -1,0 +1,42 @@
+import json
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AlipayCancelRuleRequest(AlipayRequest):
+    def __init__(self):
+        super(AlipayCancelRuleRequest, self).__init__("/ams/api/v1/payments/reserve/cancelRule") 
+
+        self.__rule_id = None  # type: str
+        
+
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned reserve rule identifier to cancel.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']

--- a/com/alipay/ams/api/request/pay/alipay_create_rule_request.py
+++ b/com/alipay/ams/api/request/pay/alipay_create_rule_request.py
@@ -1,0 +1,140 @@
+import json
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.release_type import ReleaseType
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AlipayCreateRuleRequest(AlipayRequest):
+    def __init__(self):
+        super(AlipayCreateRuleRequest, self).__init__("/ams/api/v1/payments/reserve/createRule") 
+
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_type = None  # type: ReleaseType
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        
+
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this AlipayCreateRuleRequest.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this AlipayCreateRuleRequest.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this AlipayCreateRuleRequest.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The rolling reserve percentage. An integer from 1 through 100.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this AlipayCreateRuleRequest.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def release_time(self):
+        """
+        The fixed release instant as a quoted ISO 8601 offset date-time. Required only when releaseType is FIXED_TIME. The parsed instant must be from 3 through 180 days after the server time. Do not provide this field when releaseType is INTERVAL_TIME.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The rolling retention period in days. Required only when releaseType is INTERVAL_TIME. Do not provide this field when releaseType is FIXED_TIME.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']

--- a/com/alipay/ams/api/request/pay/alipay_inquire_rule_list_request.py
+++ b/com/alipay/ams/api/request/pay/alipay_inquire_rule_list_request.py
@@ -1,0 +1,123 @@
+import json
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.release_type import ReleaseType
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AlipayInquireRuleListRequest(AlipayRequest):
+    def __init__(self):
+        super(AlipayInquireRuleListRequest, self).__init__("/ams/api/v1/payments/reserve/inquireRuleList") 
+
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__release_type = None  # type: ReleaseType
+        self.__limit = None  # type: int
+        self.__starting_after = None  # type: str
+        self.__ending_before = None  # type: str
+        
+
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this AlipayInquireRuleListRequest.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this AlipayInquireRuleListRequest.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this AlipayInquireRuleListRequest.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def limit(self):
+        """
+        The maximum number of rules to return. The default value is 10.
+        """
+        return self.__limit
+
+    @limit.setter
+    def limit(self, value):
+        self.__limit = value
+    @property
+    def starting_after(self):
+        """
+        The forward-pagination cursor. Return rules with a ruleId lower than this value in descending ruleId order. This field is mutually exclusive with endingBefore. Omission, null, empty, or blank means no cursor.
+        """
+        return self.__starting_after
+
+    @starting_after.setter
+    def starting_after(self, value):
+        self.__starting_after = value
+    @property
+    def ending_before(self):
+        """
+        The backward-pagination cursor. Return the nearest page of rules with a ruleId higher than this value, presented in descending ruleId order. This field is mutually exclusive with startingAfter. Omission, null, empty, or blank means no cursor.
+        """
+        return self.__ending_before
+
+    @ending_before.setter
+    def ending_before(self, value):
+        self.__ending_before = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "limit") and self.limit is not None:
+            params['limit'] = self.limit
+        if hasattr(self, "starting_after") and self.starting_after is not None:
+            params['startingAfter'] = self.starting_after
+        if hasattr(self, "ending_before") and self.ending_before is not None:
+            params['endingBefore'] = self.ending_before
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'limit' in response_body:
+            self.__limit = response_body['limit']
+        if 'startingAfter' in response_body:
+            self.__starting_after = response_body['startingAfter']
+        if 'endingBefore' in response_body:
+            self.__ending_before = response_body['endingBefore']

--- a/com/alipay/ams/api/request/pay/alipay_update_rule_request.py
+++ b/com/alipay/ams/api/request/pay/alipay_update_rule_request.py
@@ -1,0 +1,121 @@
+import json
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.rule_status import RuleStatus
+
+
+
+from com.alipay.ams.api.request.alipay_request import AlipayRequest
+
+class AlipayUpdateRuleRequest(AlipayRequest):
+    def __init__(self):
+        super(AlipayUpdateRuleRequest, self).__init__("/ams/api/v1/payments/reserve/updateRule") 
+
+        self.__rule_id = None  # type: str
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        self.__rule_status = None  # type: RuleStatus
+        
+
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned reserve rule identifier to update.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this AlipayUpdateRuleRequest.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The updated rolling reserve percentage. Omission or null leaves the field unchanged.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_time(self):
+        """
+        The updated fixed release instant as a quoted ISO 8601 offset date-time. This field applies only to a stored FIXED_TIME rule. Omission or null leaves the field unchanged. A supplied instant must be from 3 through 180 days after the server time.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The updated rolling retention period in days. This field applies only to a stored INTERVAL_TIME rule. Omission or null leaves the field unchanged.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+    @property
+    def rule_status(self):
+        """Gets the rule_status of this AlipayUpdateRuleRequest.
+        
+        """
+        return self.__rule_status
+
+    @rule_status.setter
+    def rule_status(self, value):
+        self.__rule_status = value
+
+
+    def to_ams_json(self): 
+        json_str = json.dumps(obj=self.to_ams_dict(), default=lambda o: o.to_ams_dict(), indent=3) 
+        return json_str
+
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        if hasattr(self, "rule_status") and self.rule_status is not None:
+            params['ruleStatus'] = self.rule_status
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        if isinstance(response_body, str): 
+            response_body = json.loads(response_body)
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']
+        if 'ruleStatus' in response_body:
+            rule_status_temp = RuleStatus.value_of(response_body['ruleStatus'])
+            self.__rule_status = rule_status_temp

--- a/com/alipay/ams/api/response/aba/alipay_inquire_card_sensitive_info_response.py
+++ b/com/alipay/ams/api/response/aba/alipay_inquire_card_sensitive_info_response.py
@@ -1,5 +1,6 @@
 import json
 from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.card_detail import CardDetail
 
 
 
@@ -15,6 +16,7 @@ class AlipayInquireCardSensitiveInfoResponse(AlipayResponse):
         self.__card_no = None  # type: str
         self.__expired_month = None  # type: str
         self.__expired_year = None  # type: str
+        self.__card_detail = None  # type: CardDetail
         self.parse_rsp_body(rsp_body) 
 
 
@@ -78,6 +80,16 @@ class AlipayInquireCardSensitiveInfoResponse(AlipayResponse):
     @expired_year.setter
     def expired_year(self, value):
         self.__expired_year = value
+    @property
+    def card_detail(self):
+        """Gets the card_detail of this AlipayInquireCardSensitiveInfoResponse.
+        
+        """
+        return self.__card_detail
+
+    @card_detail.setter
+    def card_detail(self, value):
+        self.__card_detail = value
 
 
     
@@ -96,6 +108,8 @@ class AlipayInquireCardSensitiveInfoResponse(AlipayResponse):
             params['expiredMonth'] = self.expired_month
         if hasattr(self, "expired_year") and self.expired_year is not None:
             params['expiredYear'] = self.expired_year
+        if hasattr(self, "card_detail") and self.card_detail is not None:
+            params['cardDetail'] = self.card_detail
         return params
 
 
@@ -114,3 +128,6 @@ class AlipayInquireCardSensitiveInfoResponse(AlipayResponse):
             self.__expired_month = response_body['expiredMonth']
         if 'expiredYear' in response_body:
             self.__expired_year = response_body['expiredYear']
+        if 'cardDetail' in response_body:
+            self.__card_detail = CardDetail()
+            self.__card_detail.parse_rsp_body(response_body['cardDetail'])

--- a/com/alipay/ams/api/response/billing/alipay_billing_subscription_inquire_details_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_billing_subscription_inquire_details_response.py
@@ -90,7 +90,7 @@ class AlipayBillingSubscriptionInquireDetailsResponse(AlipayResponse):
     @property
     def status(self):
         """
-        The current status. Maximum length: 20 characters.
+        The current subscription status. Valid values are INCOMPLETE, TRIALING, ACTIVE, PAST_DUE, PAUSED, CANCELLED, TERMINATED, and UNPAID. PAST_DUE means the latest renewal payment failed and collection retry is in progress. PAUSED means payment collection is suspended and the subscription can be resumed. CANCELLED remains reversible before the current billing period ends. TERMINATED is a permanent final state. UNPAID means all collection retries have been exhausted and collection remains suspended until the outstanding invoice is paid. Clients must tolerate future unknown status values and should log and alert on them instead of failing response parsing. Maximum length: 20 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/response/billing/alipay_billing_subscription_update_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_billing_subscription_update_response.py
@@ -47,7 +47,7 @@ class AlipayBillingSubscriptionUpdateResponse(AlipayResponse):
     @property
     def status(self):
         """
-        The current status. Maximum length: 20 characters.
+        The subscription status after the update. PAST_DUE means the latest renewal payment failed and collection retry is in progress. PAUSED means payment collection is suspended and can be entered by setting statusChange.action to PAUSE. CANCELLED means the subscription remains active until the current period ends and can be reverted before then by setting cancelAtPeriodEnd to false. TERMINATED is a permanent final state. Maximum length: 20 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/response/billing/alipay_customer_create_portal_link_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_customer_create_portal_link_response.py
@@ -30,7 +30,7 @@ class AlipayCustomerCreatePortalLinkResponse(AlipayResponse):
     @property
     def token(self):
         """
-        Opaque URL-safe bearer token. Treat it as a credential: do not log, parse, or store its internal structure - the format may change without notice. Returned only when result.resultCode is SUCCESS.
+        Opaque URL-safe bearer token. Treat it as a credential: do not log, parse, or store its internal structure because the format may change without notice. Maximum length: 4096 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__token
 
@@ -40,7 +40,7 @@ class AlipayCustomerCreatePortalLinkResponse(AlipayResponse):
     @property
     def portal_url(self):
         """
-        Fully-qualified portal URL. Null when the portal base URL is not configured for the merchant - in that case build the URL from &#x60;token&#x60;. Returned only when result.resultCode is SUCCESS.
+        Fully-qualified portal URL. Null when the portal base URL is not configured for the merchant; in that case, build the URL from &#x60;token&#x60;. Maximum length: 2048 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__portal_url
 
@@ -50,7 +50,7 @@ class AlipayCustomerCreatePortalLinkResponse(AlipayResponse):
     @property
     def expires_at(self):
         """
-        Token expiration timestamp. Format: &#x60;yyyy-MM-dd HH:mm:ss&#x60; (NOT ISO 8601). Returned only when result.resultCode is SUCCESS.
+        Expiration time of the portal link, returned as a string. Maximum length: 32 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__expires_at
 
@@ -60,7 +60,7 @@ class AlipayCustomerCreatePortalLinkResponse(AlipayResponse):
     @property
     def send_status(self):
         """
-        &#x60;SENT&#x60; / &#x60;FAILED&#x60;. Populated only when request &#x60;autoSend&#x3D;true&#x60;. Best-effort: failure never blocks link creation. Null when &#x60;autoSend&#x3D;false&#x60;. Returned only when result.resultCode is SUCCESS.
+        Email send status. Valid values are &#x60;SENT&#x60; and &#x60;FAILED&#x60;. Populated only when request &#x60;autoSend&#x3D;true&#x60;; a send failure never blocks link creation. Null when &#x60;autoSend&#x3D;false&#x60;. Maximum length: 16 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__send_status
 

--- a/com/alipay/ams/api/response/billing/alipay_invoice_export_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_invoice_export_response.py
@@ -15,6 +15,7 @@ class AlipayInvoiceExportResponse(AlipayResponse):
         self.__file_url = None  # type: str
         self.__file_size = None  # type: int
         self.__file_name = None  # type: str
+        self.__mode = None  # type: str
         self.parse_rsp_body(rsp_body) 
 
 
@@ -78,6 +79,16 @@ class AlipayInvoiceExportResponse(AlipayResponse):
     @file_name.setter
     def file_name(self, value):
         self.__file_name = value
+    @property
+    def mode(self):
+        """
+        Execution mode of the export request. The returned value is &#x60;SYNC&#x60;, indicating synchronous export. Maximum length: 8 characters. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__mode
+
+    @mode.setter
+    def mode(self, value):
+        self.__mode = value
 
 
     
@@ -96,6 +107,8 @@ class AlipayInvoiceExportResponse(AlipayResponse):
             params['fileSize'] = self.file_size
         if hasattr(self, "file_name") and self.file_name is not None:
             params['fileName'] = self.file_name
+        if hasattr(self, "mode") and self.mode is not None:
+            params['mode'] = self.mode
         return params
 
 
@@ -114,3 +127,5 @@ class AlipayInvoiceExportResponse(AlipayResponse):
             self.__file_size = response_body['fileSize']
         if 'fileName' in response_body:
             self.__file_name = response_body['fileName']
+        if 'mode' in response_body:
+            self.__mode = response_body['mode']

--- a/com/alipay/ams/api/response/billing/alipay_receipt_export_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_receipt_export_response.py
@@ -15,6 +15,7 @@ class AlipayReceiptExportResponse(AlipayResponse):
         self.__file_url = None  # type: str
         self.__file_size = None  # type: int
         self.__file_name = None  # type: str
+        self.__mode = None  # type: str
         self.parse_rsp_body(rsp_body) 
 
 
@@ -31,7 +32,7 @@ class AlipayReceiptExportResponse(AlipayResponse):
     @property
     def file_format(self):
         """
-        MIME type of the generated file. The response returns the MIME type corresponding to the requested format: &#x60;csv&#x60; -&gt; &#x60;text/csv&#x60;, &#x60;xlsx&#x60; -&gt; &#x60;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet&#x60;. Note: the response &#x60;fileFormat&#x60; returns the MIME type, not the request format code. The request accepts &#x60;csv&#x60;/&#x60;xlsx&#x60;. Returned only when result.resultCode is SUCCESS.
+        MIME type of the generated file. The response returns the MIME type corresponding to the requested format: &#x60;csv&#x60; -&gt; &#x60;text/csv&#x60;, &#x60;xlsx&#x60; -&gt; &#x60;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet&#x60;. Note: the response &#x60;fileFormat&#x60; returns the MIME type, not the request format code. The request accepts &#x60;csv&#x60;/&#x60;xlsx&#x60;. Maximum length: 128 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__file_format
 
@@ -51,7 +52,7 @@ class AlipayReceiptExportResponse(AlipayResponse):
     @property
     def file_url(self):
         """
-        Signed OSS URL for file download. URL is time-limited; see &#x60;expiresAt&#x60;. After expiry, accessing the URL returns HTTP 403. Returned only when result.resultCode is SUCCESS.
+        Signed OSS URL for file download. URL is time-limited; see &#x60;expiresAt&#x60;. After expiry, accessing the URL returns HTTP 403. Maximum length: 2048 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__file_url
 
@@ -71,13 +72,23 @@ class AlipayReceiptExportResponse(AlipayResponse):
     @property
     def file_name(self):
         """
-        Generated file name (e.g., &#x60;receipts_20260401_20260430_1685000000.csv&#x60;). Returned only when result.resultCode is SUCCESS.
+        Generated file name (e.g., &#x60;receipts_20260401_20260430_1685000000.csv&#x60;). Maximum length: 256 characters. Returned only when result.resultCode is SUCCESS.
         """
         return self.__file_name
 
     @file_name.setter
     def file_name(self, value):
         self.__file_name = value
+    @property
+    def mode(self):
+        """
+        Execution mode of the export request. The returned value is &#x60;SYNC&#x60;, indicating synchronous export. Maximum length: 8 characters. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__mode
+
+    @mode.setter
+    def mode(self, value):
+        self.__mode = value
 
 
     
@@ -96,6 +107,8 @@ class AlipayReceiptExportResponse(AlipayResponse):
             params['fileSize'] = self.file_size
         if hasattr(self, "file_name") and self.file_name is not None:
             params['fileName'] = self.file_name
+        if hasattr(self, "mode") and self.mode is not None:
+            params['mode'] = self.mode
         return params
 
 
@@ -114,3 +127,5 @@ class AlipayReceiptExportResponse(AlipayResponse):
             self.__file_size = response_body['fileSize']
         if 'fileName' in response_body:
             self.__file_name = response_body['fileName']
+        if 'mode' in response_body:
+            self.__mode = response_body['mode']

--- a/com/alipay/ams/api/response/billing/alipay_receipt_inquire_list_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_receipt_inquire_list_response.py
@@ -15,6 +15,7 @@ class AlipayReceiptInquireListResponse(AlipayResponse):
         self.__total = None  # type: int
         self.__has_more = None  # type: bool
         self.__next_cursor = None  # type: str
+        self.__previous_cursor = None  # type: str
         self.parse_rsp_body(rsp_body) 
 
 
@@ -68,6 +69,16 @@ class AlipayReceiptInquireListResponse(AlipayResponse):
     @next_cursor.setter
     def next_cursor(self, value):
         self.__next_cursor = value
+    @property
+    def previous_cursor(self):
+        """
+        The &#x60;receiptId&#x60; of the first receipt in the current page. Use this value as &#x60;endingBefore&#x60; in the next request to continue paging backward to earlier data. Returned only when &#x60;endingBefore&#x60; is used. Maximum length: 64 characters. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__previous_cursor
+
+    @previous_cursor.setter
+    def previous_cursor(self, value):
+        self.__previous_cursor = value
 
 
     
@@ -84,6 +95,8 @@ class AlipayReceiptInquireListResponse(AlipayResponse):
             params['hasMore'] = self.has_more
         if hasattr(self, "next_cursor") and self.next_cursor is not None:
             params['nextCursor'] = self.next_cursor
+        if hasattr(self, "previous_cursor") and self.previous_cursor is not None:
+            params['previousCursor'] = self.previous_cursor
         return params
 
 
@@ -104,3 +117,5 @@ class AlipayReceiptInquireListResponse(AlipayResponse):
             self.__has_more = response_body['hasMore']
         if 'nextCursor' in response_body:
             self.__next_cursor = response_body['nextCursor']
+        if 'previousCursor' in response_body:
+            self.__previous_cursor = response_body['previousCursor']

--- a/com/alipay/ams/api/response/billing/alipay_tax_calculate_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_calculate_response.py
@@ -3,6 +3,7 @@ from com.alipay.ams.api.model.result import Result
 from com.alipay.ams.api.model.tax_calculated_line_item import TaxCalculatedLineItem
 from com.alipay.ams.api.model.tax_breakdown import TaxBreakdown
 from com.alipay.ams.api.model.tax_calculated_shipping_cost import TaxCalculatedShippingCost
+from com.alipay.ams.api.model.tax_calculated_customer_details import TaxCalculatedCustomerDetails
 
 
 
@@ -23,6 +24,7 @@ class AlipayTaxCalculateResponse(AlipayResponse):
         self.__expire_at = None  # type: str
         self.__tax_date = None  # type: str
         self.__shipping_cost = None  # type: TaxCalculatedShippingCost
+        self.__customer_details = None  # type: TaxCalculatedCustomerDetails
         self.parse_rsp_body(rsp_body) 
 
 
@@ -136,6 +138,16 @@ class AlipayTaxCalculateResponse(AlipayResponse):
     @shipping_cost.setter
     def shipping_cost(self, value):
         self.__shipping_cost = value
+    @property
+    def customer_details(self):
+        """Gets the customer_details of this AlipayTaxCalculateResponse.
+        
+        """
+        return self.__customer_details
+
+    @customer_details.setter
+    def customer_details(self, value):
+        self.__customer_details = value
 
 
     
@@ -164,6 +176,8 @@ class AlipayTaxCalculateResponse(AlipayResponse):
             params['taxDate'] = self.tax_date
         if hasattr(self, "shipping_cost") and self.shipping_cost is not None:
             params['shippingCost'] = self.shipping_cost
+        if hasattr(self, "customer_details") and self.customer_details is not None:
+            params['customerDetails'] = self.customer_details
         return params
 
 
@@ -201,3 +215,6 @@ class AlipayTaxCalculateResponse(AlipayResponse):
         if 'shippingCost' in response_body:
             self.__shipping_cost = TaxCalculatedShippingCost()
             self.__shipping_cost.parse_rsp_body(response_body['shippingCost'])
+        if 'customerDetails' in response_body:
+            self.__customer_details = TaxCalculatedCustomerDetails()
+            self.__customer_details.parse_rsp_body(response_body['customerDetails'])

--- a/com/alipay/ams/api/response/billing/alipay_tax_cancel_registration_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_cancel_registration_response.py
@@ -45,7 +45,7 @@ class AlipayTaxCancelRegistrationResponse(AlipayResponse):
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 16 characters. Note: See documentation for details.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 
@@ -65,7 +65,7 @@ class AlipayTaxCancelRegistrationResponse(AlipayResponse):
     @property
     def registration_type(self):
         """
-        The tax registration type. Maximum length: 32 characters. Note: See documentation for details.
+        The tax registration type. Supported values are OSS_NON_UNION, STANDARD_LOCAL_TAX, SINGLE_LOCAL_USE_TAX_RATE, SIMPLIFIED_SELLERS_USE_TAX, STANDARD_SALES_AND_USE_TAX, NORMAL_GST_HST, and SIMPLIFIED_GST_HST. Maximum length: 32 characters.
         """
         return self.__registration_type
 

--- a/com/alipay/ams/api/response/billing/alipay_tax_initialize_settings_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_initialize_settings_response.py
@@ -61,7 +61,7 @@ class AlipayTaxInitializeSettingsResponse(AlipayResponse):
     @property
     def status(self):
         """
-        The current status. Maximum length: 16 characters. Note: See documentation for details.
+        The tax settings status. Valid values are ACTIVE and PENDING. Do not treat an unknown value as ACTIVE. Maximum length: 16 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/response/billing/alipay_tax_inquire_calculation_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_inquire_calculation_response.py
@@ -1,5 +1,7 @@
 import json
 from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.tax_calculated_customer_details import TaxCalculatedCustomerDetails
+from com.alipay.ams.api.model.tax_calculated_ship_from_details import TaxCalculatedShipFromDetails
 from com.alipay.ams.api.model.tax_calculated_line_item import TaxCalculatedLineItem
 from com.alipay.ams.api.model.tax_breakdown import TaxBreakdown
 from com.alipay.ams.api.model.tax_calculated_shipping_cost import TaxCalculatedShippingCost
@@ -15,6 +17,8 @@ class AlipayTaxInquireCalculationResponse(AlipayResponse):
         self.__result = None  # type: Result
         self.__tax_calculation_id = None  # type: str
         self.__currency = None  # type: str
+        self.__customer_details = None  # type: TaxCalculatedCustomerDetails
+        self.__ship_from_details = None  # type: TaxCalculatedShipFromDetails
         self.__total_amount = None  # type: str
         self.__exclusive_tax_amount = None  # type: str
         self.__inclusive_tax_amount = None  # type: str
@@ -56,6 +60,26 @@ class AlipayTaxInquireCalculationResponse(AlipayResponse):
     @currency.setter
     def currency(self, value):
         self.__currency = value
+    @property
+    def customer_details(self):
+        """Gets the customer_details of this AlipayTaxInquireCalculationResponse.
+        
+        """
+        return self.__customer_details
+
+    @customer_details.setter
+    def customer_details(self, value):
+        self.__customer_details = value
+    @property
+    def ship_from_details(self):
+        """Gets the ship_from_details of this AlipayTaxInquireCalculationResponse.
+        
+        """
+        return self.__ship_from_details
+
+    @ship_from_details.setter
+    def ship_from_details(self, value):
+        self.__ship_from_details = value
     @property
     def total_amount(self):
         """
@@ -148,6 +172,10 @@ class AlipayTaxInquireCalculationResponse(AlipayResponse):
             params['taxCalculationId'] = self.tax_calculation_id
         if hasattr(self, "currency") and self.currency is not None:
             params['currency'] = self.currency
+        if hasattr(self, "customer_details") and self.customer_details is not None:
+            params['customerDetails'] = self.customer_details
+        if hasattr(self, "ship_from_details") and self.ship_from_details is not None:
+            params['shipFromDetails'] = self.ship_from_details
         if hasattr(self, "total_amount") and self.total_amount is not None:
             params['totalAmount'] = self.total_amount
         if hasattr(self, "exclusive_tax_amount") and self.exclusive_tax_amount is not None:
@@ -176,6 +204,12 @@ class AlipayTaxInquireCalculationResponse(AlipayResponse):
             self.__tax_calculation_id = response_body['taxCalculationId']
         if 'currency' in response_body:
             self.__currency = response_body['currency']
+        if 'customerDetails' in response_body:
+            self.__customer_details = TaxCalculatedCustomerDetails()
+            self.__customer_details.parse_rsp_body(response_body['customerDetails'])
+        if 'shipFromDetails' in response_body:
+            self.__ship_from_details = TaxCalculatedShipFromDetails()
+            self.__ship_from_details.parse_rsp_body(response_body['shipFromDetails'])
         if 'totalAmount' in response_body:
             self.__total_amount = response_body['totalAmount']
         if 'exclusiveTaxAmount' in response_body:

--- a/com/alipay/ams/api/response/billing/alipay_tax_inquire_settings_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_inquire_settings_response.py
@@ -31,7 +31,7 @@ class AlipayTaxInquireSettingsResponse(AlipayResponse):
     @property
     def default_tax_code(self):
         """
-        The default tax code. Maximum length: 32 characters.
+        The default tax code. Returned only when the API call succeeds. Maximum length: 32 characters.
         """
         return self.__default_tax_code
 
@@ -41,7 +41,7 @@ class AlipayTaxInquireSettingsResponse(AlipayResponse):
     @property
     def default_tax_behavior(self):
         """
-        The default tax behavior. Maximum length: 16 characters.
+        The default tax behavior. Returned only when the API call succeeds. Maximum length: 16 characters.
         """
         return self.__default_tax_behavior
 
@@ -61,7 +61,7 @@ class AlipayTaxInquireSettingsResponse(AlipayResponse):
     @property
     def status(self):
         """
-        The current status. Maximum length: 16 characters. Note: See documentation for details.
+        The tax settings status. Valid values are ACTIVE and PENDING. Returned only when the API call succeeds. Maximum length: 16 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/response/billing/alipay_tax_register_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_register_response.py
@@ -45,7 +45,7 @@ class AlipayTaxRegisterResponse(AlipayResponse):
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 16 characters. Note: See documentation for details.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 
@@ -65,7 +65,7 @@ class AlipayTaxRegisterResponse(AlipayResponse):
     @property
     def registration_type(self):
         """
-        The tax registration type. Maximum length: 32 characters. Note: See documentation for details.
+        The tax registration type. Supported values are OSS_NON_UNION, STANDARD_LOCAL_TAX, SINGLE_LOCAL_USE_TAX_RATE, SIMPLIFIED_SELLERS_USE_TAX, STANDARD_SALES_AND_USE_TAX, NORMAL_GST_HST, and SIMPLIFIED_GST_HST. Maximum length: 32 characters.
         """
         return self.__registration_type
 

--- a/com/alipay/ams/api/response/billing/alipay_tax_update_registration_period_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_update_registration_period_response.py
@@ -45,7 +45,7 @@ class AlipayTaxUpdateRegistrationPeriodResponse(AlipayResponse):
     @property
     def tax_type(self):
         """
-        The tax type. Maximum length: 16 characters. Note: See documentation for details.
+        The tax type. Supported values include CUIT, GST, VAT, CBS, IBS, HST, PST, RST, QST, JCT, SERVICE_TAX, IGV, SALES_TAX, and PERSONAL_PROPERTY_LEASE_TRANSACTION_TAX.
         """
         return self.__tax_type
 
@@ -65,7 +65,7 @@ class AlipayTaxUpdateRegistrationPeriodResponse(AlipayResponse):
     @property
     def registration_type(self):
         """
-        The tax registration type. Maximum length: 32 characters. Note: See documentation for details.
+        The tax registration type. Supported values are OSS_NON_UNION, STANDARD_LOCAL_TAX, SINGLE_LOCAL_USE_TAX_RATE, SIMPLIFIED_SELLERS_USE_TAX, STANDARD_SALES_AND_USE_TAX, NORMAL_GST_HST, and SIMPLIFIED_GST_HST. Maximum length: 32 characters.
         """
         return self.__registration_type
 

--- a/com/alipay/ams/api/response/billing/alipay_tax_update_settings_response.py
+++ b/com/alipay/ams/api/response/billing/alipay_tax_update_settings_response.py
@@ -61,7 +61,7 @@ class AlipayTaxUpdateSettingsResponse(AlipayResponse):
     @property
     def status(self):
         """
-        The current status. Maximum length: 16 characters. Note: See documentation for details.
+        The tax settings status. Valid values are ACTIVE and PENDING. A valid update to ACTIVE settings keeps the status ACTIVE; do not treat an unknown value as ACTIVE. Maximum length: 16 characters.
         """
         return self.__status
 

--- a/com/alipay/ams/api/response/pay/alipay_cancel_rule_response.py
+++ b/com/alipay/ams/api/response/pay/alipay_cancel_rule_response.py
@@ -1,0 +1,231 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.release_type import ReleaseType
+from com.alipay.ams.api.model.rule_status import RuleStatus
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AlipayCancelRuleResponse(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__rule_id = None  # type: str
+        self.__merchant_id = None  # type: str
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_type = None  # type: ReleaseType
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        self.__rule_status = None  # type: RuleStatus
+        self.__create_time = None  # type: str
+        self.__update_time = None  # type: str
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned positive numeric reserve rule identifier. Save and return this value unchanged for updates, cancellation, and cursor pagination. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+    @property
+    def merchant_id(self):
+        """
+        The ID of the merchant that owns the reserve rule. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__merchant_id
+
+    @merchant_id.setter
+    def merchant_id(self, value):
+        self.__merchant_id = value
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The rolling reserve percentage. Returned when takeType is ROLLING and result.resultCode is SUCCESS.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def release_time(self):
+        """
+        The fixed release instant as an ISO 8601 UTC string, for example 2026-12-31T16:00:00Z. Returned when releaseType is FIXED_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The rolling retention period in days. Returned when releaseType is INTERVAL_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+    @property
+    def rule_status(self):
+        """Gets the rule_status of this AlipayCancelRuleResponse.
+        
+        """
+        return self.__rule_status
+
+    @rule_status.setter
+    def rule_status(self, value):
+        self.__rule_status = value
+    @property
+    def create_time(self):
+        """
+        The rule creation time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__create_time
+
+    @create_time.setter
+    def create_time(self, value):
+        self.__create_time = value
+    @property
+    def update_time(self):
+        """
+        The rule last-update time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__update_time
+
+    @update_time.setter
+    def update_time(self, value):
+        self.__update_time = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        if hasattr(self, "merchant_id") and self.merchant_id is not None:
+            params['merchantId'] = self.merchant_id
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        if hasattr(self, "rule_status") and self.rule_status is not None:
+            params['ruleStatus'] = self.rule_status
+        if hasattr(self, "create_time") and self.create_time is not None:
+            params['createTime'] = self.create_time
+        if hasattr(self, "update_time") and self.update_time is not None:
+            params['updateTime'] = self.update_time
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AlipayCancelRuleResponse, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']
+        if 'merchantId' in response_body:
+            self.__merchant_id = response_body['merchantId']
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']
+        if 'ruleStatus' in response_body:
+            rule_status_temp = RuleStatus.value_of(response_body['ruleStatus'])
+            self.__rule_status = rule_status_temp
+        if 'createTime' in response_body:
+            self.__create_time = response_body['createTime']
+        if 'updateTime' in response_body:
+            self.__update_time = response_body['updateTime']

--- a/com/alipay/ams/api/response/pay/alipay_create_rule_response.py
+++ b/com/alipay/ams/api/response/pay/alipay_create_rule_response.py
@@ -1,0 +1,231 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.release_type import ReleaseType
+from com.alipay.ams.api.model.rule_status import RuleStatus
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AlipayCreateRuleResponse(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__rule_id = None  # type: str
+        self.__merchant_id = None  # type: str
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_type = None  # type: ReleaseType
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        self.__rule_status = None  # type: RuleStatus
+        self.__create_time = None  # type: str
+        self.__update_time = None  # type: str
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned positive numeric reserve rule identifier. Save and return this value unchanged for updates, cancellation, and cursor pagination. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+    @property
+    def merchant_id(self):
+        """
+        The ID of the merchant that owns the reserve rule. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__merchant_id
+
+    @merchant_id.setter
+    def merchant_id(self, value):
+        self.__merchant_id = value
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The rolling reserve percentage. Returned when takeType is ROLLING and result.resultCode is SUCCESS.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def release_time(self):
+        """
+        The fixed release instant as an ISO 8601 UTC string, for example 2026-12-31T16:00:00Z. Returned when releaseType is FIXED_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The rolling retention period in days. Returned when releaseType is INTERVAL_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+    @property
+    def rule_status(self):
+        """Gets the rule_status of this AlipayCreateRuleResponse.
+        
+        """
+        return self.__rule_status
+
+    @rule_status.setter
+    def rule_status(self, value):
+        self.__rule_status = value
+    @property
+    def create_time(self):
+        """
+        The rule creation time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__create_time
+
+    @create_time.setter
+    def create_time(self, value):
+        self.__create_time = value
+    @property
+    def update_time(self):
+        """
+        The rule last-update time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__update_time
+
+    @update_time.setter
+    def update_time(self, value):
+        self.__update_time = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        if hasattr(self, "merchant_id") and self.merchant_id is not None:
+            params['merchantId'] = self.merchant_id
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        if hasattr(self, "rule_status") and self.rule_status is not None:
+            params['ruleStatus'] = self.rule_status
+        if hasattr(self, "create_time") and self.create_time is not None:
+            params['createTime'] = self.create_time
+        if hasattr(self, "update_time") and self.update_time is not None:
+            params['updateTime'] = self.update_time
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AlipayCreateRuleResponse, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']
+        if 'merchantId' in response_body:
+            self.__merchant_id = response_body['merchantId']
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']
+        if 'ruleStatus' in response_body:
+            rule_status_temp = RuleStatus.value_of(response_body['ruleStatus'])
+            self.__rule_status = rule_status_temp
+        if 'createTime' in response_body:
+            self.__create_time = response_body['createTime']
+        if 'updateTime' in response_body:
+            self.__update_time = response_body['updateTime']

--- a/com/alipay/ams/api/response/pay/alipay_inquire_rule_list_response.py
+++ b/com/alipay/ams/api/response/pay/alipay_inquire_rule_list_response.py
@@ -1,0 +1,76 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.reserve_rule import ReserveRule
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AlipayInquireRuleListResponse(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__has_more = None  # type: bool
+        self.__rules = None  # type: [ReserveRule]
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AlipayInquireRuleListResponse.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def has_more(self):
+        """
+        Whether another page of rules is available. This field is false when rules is empty.
+        """
+        return self.__has_more
+
+    @has_more.setter
+    def has_more(self, value):
+        self.__has_more = value
+    @property
+    def rules(self):
+        """
+        The reserve rules in descending ruleId order. An empty result is returned as an empty array.
+        """
+        return self.__rules
+
+    @rules.setter
+    def rules(self, value):
+        self.__rules = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "has_more") and self.has_more is not None:
+            params['hasMore'] = self.has_more
+        if hasattr(self, "rules") and self.rules is not None:
+            params['rules'] = self.rules
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AlipayInquireRuleListResponse, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'hasMore' in response_body:
+            self.__has_more = response_body['hasMore']
+        if 'rules' in response_body:
+            self.__rules = []
+            for item in response_body['rules']:
+                obj = ReserveRule()
+                obj.parse_rsp_body(item)
+                self.__rules.append(obj)

--- a/com/alipay/ams/api/response/pay/alipay_update_rule_response.py
+++ b/com/alipay/ams/api/response/pay/alipay_update_rule_response.py
@@ -1,0 +1,231 @@
+import json
+from com.alipay.ams.api.model.result import Result
+from com.alipay.ams.api.model.funds_type import FundsType
+from com.alipay.ams.api.model.take_type import TakeType
+from com.alipay.ams.api.model.payment_method_scope import PaymentMethodScope
+from com.alipay.ams.api.model.release_type import ReleaseType
+from com.alipay.ams.api.model.rule_status import RuleStatus
+
+
+
+from com.alipay.ams.api.response.alipay_response import AlipayResponse
+
+class AlipayUpdateRuleResponse(AlipayResponse):
+    def __init__(self, rsp_body):
+        super(AlipayResponse, self).__init__() 
+
+        self.__result = None  # type: Result
+        self.__rule_id = None  # type: str
+        self.__merchant_id = None  # type: str
+        self.__funds_type = None  # type: FundsType
+        self.__take_type = None  # type: TakeType
+        self.__payment_method_scope = None  # type: PaymentMethodScope
+        self.__ratio = None  # type: int
+        self.__release_type = None  # type: ReleaseType
+        self.__release_time = None  # type: str
+        self.__retention_time = None  # type: int
+        self.__rule_status = None  # type: RuleStatus
+        self.__create_time = None  # type: str
+        self.__update_time = None  # type: str
+        self.parse_rsp_body(rsp_body) 
+
+
+    @property
+    def result(self):
+        """Gets the result of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__result
+
+    @result.setter
+    def result(self, value):
+        self.__result = value
+    @property
+    def rule_id(self):
+        """
+        The Antom-assigned positive numeric reserve rule identifier. Save and return this value unchanged for updates, cancellation, and cursor pagination. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__rule_id
+
+    @rule_id.setter
+    def rule_id(self, value):
+        self.__rule_id = value
+    @property
+    def merchant_id(self):
+        """
+        The ID of the merchant that owns the reserve rule. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__merchant_id
+
+    @merchant_id.setter
+    def merchant_id(self, value):
+        self.__merchant_id = value
+    @property
+    def funds_type(self):
+        """Gets the funds_type of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__funds_type
+
+    @funds_type.setter
+    def funds_type(self, value):
+        self.__funds_type = value
+    @property
+    def take_type(self):
+        """Gets the take_type of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__take_type
+
+    @take_type.setter
+    def take_type(self, value):
+        self.__take_type = value
+    @property
+    def payment_method_scope(self):
+        """Gets the payment_method_scope of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__payment_method_scope
+
+    @payment_method_scope.setter
+    def payment_method_scope(self, value):
+        self.__payment_method_scope = value
+    @property
+    def ratio(self):
+        """
+        The rolling reserve percentage. Returned when takeType is ROLLING and result.resultCode is SUCCESS.
+        """
+        return self.__ratio
+
+    @ratio.setter
+    def ratio(self, value):
+        self.__ratio = value
+    @property
+    def release_type(self):
+        """Gets the release_type of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__release_type
+
+    @release_type.setter
+    def release_type(self, value):
+        self.__release_type = value
+    @property
+    def release_time(self):
+        """
+        The fixed release instant as an ISO 8601 UTC string, for example 2026-12-31T16:00:00Z. Returned when releaseType is FIXED_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__release_time
+
+    @release_time.setter
+    def release_time(self, value):
+        self.__release_time = value
+    @property
+    def retention_time(self):
+        """
+        The rolling retention period in days. Returned when releaseType is INTERVAL_TIME and result.resultCode is SUCCESS.
+        """
+        return self.__retention_time
+
+    @retention_time.setter
+    def retention_time(self, value):
+        self.__retention_time = value
+    @property
+    def rule_status(self):
+        """Gets the rule_status of this AlipayUpdateRuleResponse.
+        
+        """
+        return self.__rule_status
+
+    @rule_status.setter
+    def rule_status(self, value):
+        self.__rule_status = value
+    @property
+    def create_time(self):
+        """
+        The rule creation time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__create_time
+
+    @create_time.setter
+    def create_time(self, value):
+        self.__create_time = value
+    @property
+    def update_time(self):
+        """
+        The rule last-update time as an ISO 8601 UTC string. Returned only when result.resultCode is SUCCESS.
+        """
+        return self.__update_time
+
+    @update_time.setter
+    def update_time(self, value):
+        self.__update_time = value
+
+
+    
+
+    def to_ams_dict(self):
+        params = dict()
+        if hasattr(self, "result") and self.result is not None:
+            params['result'] = self.result
+        if hasattr(self, "rule_id") and self.rule_id is not None:
+            params['ruleId'] = self.rule_id
+        if hasattr(self, "merchant_id") and self.merchant_id is not None:
+            params['merchantId'] = self.merchant_id
+        if hasattr(self, "funds_type") and self.funds_type is not None:
+            params['fundsType'] = self.funds_type
+        if hasattr(self, "take_type") and self.take_type is not None:
+            params['takeType'] = self.take_type
+        if hasattr(self, "payment_method_scope") and self.payment_method_scope is not None:
+            params['paymentMethodScope'] = self.payment_method_scope
+        if hasattr(self, "ratio") and self.ratio is not None:
+            params['ratio'] = self.ratio
+        if hasattr(self, "release_type") and self.release_type is not None:
+            params['releaseType'] = self.release_type
+        if hasattr(self, "release_time") and self.release_time is not None:
+            params['releaseTime'] = self.release_time
+        if hasattr(self, "retention_time") and self.retention_time is not None:
+            params['retentionTime'] = self.retention_time
+        if hasattr(self, "rule_status") and self.rule_status is not None:
+            params['ruleStatus'] = self.rule_status
+        if hasattr(self, "create_time") and self.create_time is not None:
+            params['createTime'] = self.create_time
+        if hasattr(self, "update_time") and self.update_time is not None:
+            params['updateTime'] = self.update_time
+        return params
+
+
+    def parse_rsp_body(self, response_body):
+        response_body = super(AlipayUpdateRuleResponse, self).parse_rsp_body(response_body)
+        if 'result' in response_body:
+            self.__result = Result()
+            self.__result.parse_rsp_body(response_body['result'])
+        if 'ruleId' in response_body:
+            self.__rule_id = response_body['ruleId']
+        if 'merchantId' in response_body:
+            self.__merchant_id = response_body['merchantId']
+        if 'fundsType' in response_body:
+            funds_type_temp = FundsType.value_of(response_body['fundsType'])
+            self.__funds_type = funds_type_temp
+        if 'takeType' in response_body:
+            take_type_temp = TakeType.value_of(response_body['takeType'])
+            self.__take_type = take_type_temp
+        if 'paymentMethodScope' in response_body:
+            payment_method_scope_temp = PaymentMethodScope.value_of(response_body['paymentMethodScope'])
+            self.__payment_method_scope = payment_method_scope_temp
+        if 'ratio' in response_body:
+            self.__ratio = response_body['ratio']
+        if 'releaseType' in response_body:
+            release_type_temp = ReleaseType.value_of(response_body['releaseType'])
+            self.__release_type = release_type_temp
+        if 'releaseTime' in response_body:
+            self.__release_time = response_body['releaseTime']
+        if 'retentionTime' in response_body:
+            self.__retention_time = response_body['retentionTime']
+        if 'ruleStatus' in response_body:
+            rule_status_temp = RuleStatus.value_of(response_body['ruleStatus'])
+            self.__rule_status = rule_status_temp
+        if 'createTime' in response_body:
+            self.__create_time = response_body['createTime']
+        if 'updateTime' in response_body:
+            self.__update_time = response_body['updateTime']


### PR DESCRIPTION
- Update generated SDK models for the latest API contract.
- Add payment reserve APIs, ABA card details, Billing subscription and export fields, and Tax model changes.
- Bump the SDK release version.

Source: [OpenAPI commit](https://github.com/TeaDrinkerPlus/antom-openapi/commit/16206c9b961e58e508e0ea8398869b59df926265) and [generation diff](https://github.com/TeaDrinkerPlus/antom-adk-automation/actions/runs/32698228112).

Validation: Wheel and sdist builds, Twine checks, and isolated Billing consumer checks passed.