### PR TITLE
chore(release): prepare Python SDK 1.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：Python  
 Python version：2.7+  
-Release ^1.5.7
+Release ^1.5.8
 Copyright：Ant financial services group  
 ```
 

--- a/com/alipay/ams/api/_version.py
+++ b/com/alipay/ams/api/_version.py
@@ -1,2 +1,2 @@
-VERSION = "1.5.7"
+VERSION = "1.5.8"
 USER_AGENT = "global-open-sdk-python/" + VERSION


### PR DESCRIPTION
## Summary
- Bump global-open-sdk-python from 1.5.7 to 1.5.8.
- Prepare the merged Payment Hold/Release API updates for publication.

## Validation
- Post-merge release regression: Offline 18/18 and Sandbox 5/5 passed.
- Wheel and sdist builds passed twine checks.
- Both artifacts installed successfully in isolated environments.
- Version, User-Agent, and new Hold/Release imports were verified.
- Git, wheel, and sdist case-collision checks passed.

## Scope
This PR changes only the SDK version source and README version example.